### PR TITLE
Improve overkiller

### DIFF
--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -266,16 +266,17 @@ static class ExtendedPlayerControl
         }
         player.ResetKillCooldown();
     }
-    public static void RpcSpecificMurderPlayer(this PlayerControl killer, PlayerControl target = null)
+    public static void RpcSpecificMurderPlayer(this PlayerControl killer, PlayerControl target = null, PlayerControl seer = null)
     {
         if (target == null) target = killer;
-        if (killer.AmOwner)
+        if (seer == null) seer = killer;
+        if (killer.AmOwner && seer.AmOwner)
         {
             killer.MurderPlayer(target);
         }
         else
         {
-            MessageWriter messageWriter = AmongUsClient.Instance.StartRpcImmediately(killer.NetId, (byte)RpcCalls.MurderPlayer, SendOption.Reliable, killer.GetClientId());
+            MessageWriter messageWriter = AmongUsClient.Instance.StartRpcImmediately(killer.NetId, (byte)RpcCalls.MurderPlayer, SendOption.Reliable, seer.GetClientId());
             messageWriter.WriteNetObject(target);
             AmongUsClient.Instance.FinishRpcImmediately(messageWriter);
         }

--- a/Patches/PlayerControlPatch.cs
+++ b/Patches/PlayerControlPatch.cs
@@ -647,6 +647,7 @@ class CheckMurderPatch
                 if (!Main.OverDeadPlayerList.Contains(target.PlayerId)) Main.OverDeadPlayerList.Add(target.PlayerId);
                 var ops = target.GetTruePosition();
                 var rd = IRandom.Instance;
+                target.Data.IsDead = true;
                 for (int i = 0; i < 20; i++)
                 {
                     Vector2 location = new(ops.x + ((float)(rd.Next(0, 201) - 100) / 100), ops.y + ((float)(rd.Next(0, 201) - 100) / 100));
@@ -669,9 +670,10 @@ class CheckMurderPatch
                         rp.RpcMurderPlayerV3(rp);
                     }
 
-                    MessageWriter messageWriter = AmongUsClient.Instance.StartRpcImmediately(killer.NetId, (byte)RpcCalls.MurderPlayer, SendOption.None, -1);
-                    messageWriter.WriteNetObject(target);
-                    AmongUsClient.Instance.FinishRpcImmediately(messageWriter);
+                    Main.AllAlivePlayerControls.Where(x => x.PlayerId != target.PlayerId && !x.AmOwner)
+                        .Do(x => killer.RpcSpecificMurderPlayer(target, x));
+                    //May cause huge rpc workload for host
+                    //Originally clients can only see 1 dead body at a spot.
                 }
                 killer.RpcTeleport(ops);
             }, 0.05f, "OverKiller Murder");


### PR DESCRIPTION
Attempt to prevent target being spam killed.
Send rpc calls to alive players except target should be working
but this may cause huge rpc workloads for host
(IDK whether this will kick host, I cannot tested it in online games)

Note that originally client can only see bodies lying together at most conditions, so this pr does not change any thing else.