### PR TITLE
Improve overkiller

### DIFF
--- a/Modules/Camouflague.cs
+++ b/Modules/Camouflague.cs
@@ -40,6 +40,8 @@ public static class Camouflage
     public static bool IsCamouflage;
     public static Dictionary<byte, GameData.PlayerOutfit> PlayerSkins = new();
 
+    public static List<byte> ResetSkinAfterDeathPlayers = new();
+
     public static void Init()
     {
         IsCamouflage = false;

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -266,16 +266,17 @@ static class ExtendedPlayerControl
         }
         player.ResetKillCooldown();
     }
-    public static void RpcSpecificMurderPlayer(this PlayerControl killer, PlayerControl target = null)
+    public static void RpcSpecificMurderPlayer(this PlayerControl killer, PlayerControl target = null, PlayerControl seer = null)
     {
         if (target == null) target = killer;
-        if (killer.AmOwner)
+        if (seer == null) seer = killer;
+        if (killer.AmOwner && seer.AmOwner)
         {
             killer.MurderPlayer(target);
         }
         else
         {
-            MessageWriter messageWriter = AmongUsClient.Instance.StartRpcImmediately(killer.NetId, (byte)RpcCalls.MurderPlayer, SendOption.Reliable, killer.GetClientId());
+            MessageWriter messageWriter = AmongUsClient.Instance.StartRpcImmediately(killer.NetId, (byte)RpcCalls.MurderPlayer, SendOption.Reliable, seer.GetClientId());
             messageWriter.WriteNetObject(target);
             AmongUsClient.Instance.FinishRpcImmediately(messageWriter);
         }

--- a/Modules/OptionHolder.cs
+++ b/Modules/OptionHolder.cs
@@ -2543,7 +2543,7 @@ public static class Options
                 .SetValueFormat(OptionFormat.Seconds); */
         BallLightning.SetupCustomOption();
         Eraser.SetupCustomOption();
-        SetupRoleOptions(16900, TabGroup.OtherRoles, CustomRoles.OverKiller);
+        OverKiller.SetupCustomOption();
         Disperser.SetupCustomOption();
         Hangman.SetupCustomOption();
         Blackmailer.SetupCustomOption();

--- a/Patches/PetsPatch.cs
+++ b/Patches/PetsPatch.cs
@@ -7,6 +7,7 @@ public static class PetsPatch
         if (pc == null || !pc.Data.IsDead) return;
         if (!GameStates.IsInGame) return;
         if (!Options.RemovePetsAtDeadPlayers.GetBool()) return;
+        if (pc.CurrentOutfit.PetId == "") return;
 
         var sender = CustomRpcSender.Create(name: "Remove Pet At Dead Player");
 

--- a/Patches/PlayerControlPatch.cs
+++ b/Patches/PlayerControlPatch.cs
@@ -647,6 +647,7 @@ class CheckMurderPatch
                 if (!Main.OverDeadPlayerList.Contains(target.PlayerId)) Main.OverDeadPlayerList.Add(target.PlayerId);
                 var ops = target.GetTruePosition();
                 var rd = IRandom.Instance;
+                target.Data.IsDead = true;
                 for (int i = 0; i < 20; i++)
                 {
                     Vector2 location = new(ops.x + ((float)(rd.Next(0, 201) - 100) / 100), ops.y + ((float)(rd.Next(0, 201) - 100) / 100));
@@ -669,9 +670,10 @@ class CheckMurderPatch
                         rp.RpcMurderPlayerV3(rp);
                     }
 
-                    MessageWriter messageWriter = AmongUsClient.Instance.StartRpcImmediately(killer.NetId, (byte)RpcCalls.MurderPlayer, SendOption.None, -1);
-                    messageWriter.WriteNetObject(target);
-                    AmongUsClient.Instance.FinishRpcImmediately(messageWriter);
+                    Main.AllAlivePlayerControls.Where(x => x.PlayerId != target.PlayerId && !x.AmOwner)
+                        .Do(x => killer.RpcSpecificMurderPlayer(target, x));
+                    //May cause huge rpc workload for host
+                    //Originally clients can only see 1 dead body at a spot.
                 }
                 killer.RpcTeleport(ops);
             }, 0.05f, "OverKiller Murder");

--- a/Patches/PlayerControlPatch.cs
+++ b/Patches/PlayerControlPatch.cs
@@ -638,46 +638,6 @@ class CheckMurderPatch
             }
 
         }
-        // 肢解者肢解受害者
-        if (killer.Is(CustomRoles.OverKiller) && killer.PlayerId != target.PlayerId)
-        {
-            Main.PlayerStates[target.PlayerId].deathReason = PlayerState.DeathReason.Dismembered;
-            _ = new LateTask(() =>
-            {
-                if (!Main.OverDeadPlayerList.Contains(target.PlayerId)) Main.OverDeadPlayerList.Add(target.PlayerId);
-                var ops = target.GetTruePosition();
-                var rd = IRandom.Instance;
-                target.Data.IsDead = true;
-                for (int i = 0; i < 20; i++)
-                {
-                    Vector2 location = new(ops.x + ((float)(rd.Next(0, 201) - 100) / 100), ops.y + ((float)(rd.Next(0, 201) - 100) / 100));
-                    location += new Vector2(0, 0.3636f);
-
-                    MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(target.NetTransform.NetId, (byte)RpcCalls.SnapTo, SendOption.None, -1);
-                    NetHelpers.WriteVector2(location, writer);
-                    writer.Write(target.NetTransform.lastSequenceId);
-                    AmongUsClient.Instance.FinishRpcImmediately(writer);
-
-                    target.NetTransform.SnapTo(location);
-                    killer.MurderPlayer(target);
-
-                    if (target.Is(CustomRoles.Avanger))
-                    {
-                        var pcList = Main.AllAlivePlayerControls.Where(x => x.PlayerId != target.PlayerId || Pelican.IsEaten(x.PlayerId) || Medic.ProtectList.Contains(x.PlayerId) || target.Is(CustomRoles.Pestilence)).ToList();
-                        var rp = pcList[IRandom.Instance.Next(0, pcList.Count)];
-                        Main.PlayerStates[rp.PlayerId].deathReason = PlayerState.DeathReason.Revenge;
-                        rp.SetRealKiller(target);
-                        rp.RpcMurderPlayerV3(rp);
-                    }
-
-                    Main.AllAlivePlayerControls.Where(x => x.PlayerId != target.PlayerId && !x.AmOwner)
-                        .Do(x => killer.RpcSpecificMurderPlayer(target, x));
-                    //May cause huge rpc workload for host
-                    //Originally clients can only see 1 dead body at a spot.
-                }
-                killer.RpcTeleport(ops);
-            }, 0.05f, "OverKiller Murder");
-        }
 
         if (killer.Is(CustomRoles.Berserker))
         {
@@ -1225,8 +1185,11 @@ class MurderPlayerPatch
         Logger.Info($"{__instance.GetNameWithRole()} => {target.GetNameWithRole()}{(target.protectedByGuardian ? "(Protected)" : "")}", "MurderPlayer");
 
         if (RandomSpawn.CustomNetworkTransformPatch.NumOfTP.TryGetValue(__instance.PlayerId, out var num) && num > 2) RandomSpawn.CustomNetworkTransformPatch.NumOfTP[__instance.PlayerId] = 3;
-        if (!target.protectedByGuardian && !Doppelganger.DoppelVictim.ContainsKey(target.PlayerId))
+        if (!target.protectedByGuardian && !Doppelganger.DoppelVictim.ContainsKey(target.PlayerId) && !Camouflage.ResetSkinAfterDeathPlayers.Contains(target.PlayerId))
+        {
+            Camouflage.ResetSkinAfterDeathPlayers.Add(target.PlayerId);
             Camouflage.RpcSetSkin(target, ForceRevert: true);
+        }
     }
     public static void Postfix(PlayerControl __instance, [HarmonyArgument(0)] PlayerControl target)
     {
@@ -1348,6 +1311,9 @@ class MurderPlayerPatch
                 break;
             case CustomRoles.Wildling:
                 Wildling.OnMurderPlayer(killer, target);
+                break;
+            case CustomRoles.OverKiller:
+                OverKiller.OnMurderPlayer(killer, target);
                 break;
         }
 

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -183,6 +183,7 @@ internal class ChangeRoleSettings
                 Camouflage.PlayerSkins[pc.PlayerId] = new GameData.PlayerOutfit().Set(outfit.PlayerName, outfit.ColorId, outfit.HatId, outfit.SkinId, outfit.VisorId, outfit.PetId, outfit.NamePlateId);
                 Main.clientIdList.Add(pc.GetClientId());
             }
+            Camouflage.ResetSkinAfterDeathPlayers = new();
             Main.VisibleTasksCount = true;
             if (__instance.AmHost)
             {

--- a/Roles/Impostor/OverKiller.cs
+++ b/Roles/Impostor/OverKiller.cs
@@ -1,0 +1,71 @@
+﻿using HarmonyLib;
+using System.Collections.Generic;
+using System.Linq;
+using TOHE.Roles.Crewmate;
+using TOHE.Roles.Neutral;
+using UnityEngine;
+using static TOHE.Options;
+using System.Threading;
+
+namespace TOHE.Roles.Impostor
+{
+    public static class OverKiller
+    {
+        private static readonly int Id = 16900;
+
+        public static List<byte> playerIdList = new();
+        public static bool IsEnable = false;
+
+        public static void SetupCustomOption()
+        {
+            SetupRoleOptions(Id, TabGroup.OtherRoles, CustomRoles.OverKiller);
+        }
+        public static void OnMurderPlayer(PlayerControl killer, PlayerControl target)
+        {
+            if (killer.PlayerId == target.PlayerId || target == null) return;
+
+            target.SetRealKiller(killer);
+            Main.PlayerStates[target.PlayerId].deathReason = PlayerState.DeathReason.Dismembered;
+            target.Data.IsDead = true;
+
+            if (!Main.OverDeadPlayerList.Contains(target.PlayerId)) Main.OverDeadPlayerList.Add(target.PlayerId);
+            var ops = target.GetTruePosition();
+            var rd = IRandom.Instance;
+
+            _ = new LateTask(() =>
+            {
+                for (int i = 0; i <= 25; i++)
+                {
+                    if (GameStates.IsMeeting) break;
+                    if (!target.AmOwner)
+                        target.MurderPlayer(target);
+                    Main.AllAlivePlayerControls.Where(x => x.PlayerId != target.PlayerId && !x.AmOwner)
+                    .Do(x => target.RpcSpecificMurderPlayer(target, x));
+                }
+            }, 0.3f, "OverKillerShowBodies"); //25 exactly takes over the whole screen
+
+            if (target.Is(CustomRoles.Avanger))
+            {
+                var pcList = Main.AllAlivePlayerControls.Where(x => x.PlayerId != target.PlayerId || Pelican.IsEaten(x.PlayerId) || Medic.ProtectList.Contains(x.PlayerId) || target.Is(CustomRoles.Pestilence));
+                pcList.Do(x => x.SetRealKiller(target));
+                pcList.Do(x => Main.PlayerStates[x.PlayerId].deathReason = PlayerState.DeathReason.Revenge);
+                pcList.Do(x => x.RpcMurderPlayerV3(x));
+            }
+
+            //for (int i = 0; i < 5; i++)
+            //{
+            //    if (GameStates.IsMeeting) break;
+            //    Vector2 location = new(ops.x + ((float)(rd.Next(0, 201) - 100) / 100), ops.y + ((float)(rd.Next(0, 201) - 100) / 100));
+            //    location += new Vector2(0, 0.3636f);
+
+            //    target.RpcTeleport(location);
+            //    Thread.Sleep(100);
+            //    target.RpcMurderPlayerV3(target);
+            //}
+            //killer.RpcTeleport(ops);
+
+            /*target wont move in clients' view , possibly bcz the delay of snapto & murderplayer
+            Niko dk how 2 fix it. leave this out until some one fix it */
+        }
+    }
+}


### PR DESCRIPTION
1.Now target wont enjoy spam death animations
2.Temporarily removed the feature where bodies lying randomly (Previously only host can see it)

Addition:
1.wont do reset pet after death for those without pets  (to avoid huge logs)
2.wont repeatly do Camouflage.RpcSetSkin for dead players  (to avoid huge logs)
3.change rpcspecificMurderPlayer so it can really choose a seer for murder player

Problems: (why its still experimental)
Huge rpc workload for host and huge logs on murderplayer