### PR TITLE
Add Fungle to "Anti Adminer", "Monitor" and add the posibility to disable devices on the fungle

### DIFF
--- a/Modules/DisableDevice.cs
+++ b/Modules/DisableDevice.cs
@@ -1,6 +1,7 @@
 using HarmonyLib;
 using System;
 using System.Collections.Generic;
+using System.Numerics;
 using UnityEngine;
 
 namespace TOHE;
@@ -24,7 +25,9 @@ class DisableDevice
         ["AirshipCockpitAdmin"] = new Vector2 (-22.32f, 0.91f),
         ["AirshipRecordsAdmin"] = new Vector2 (19.89f, 12.60f),
         ["AirshipCamera"] = new Vector2 (8.10f, -9.63f),
-        ["AirshipVital"] = new Vector2 (25.24f, -7.94f)
+        ["AirshipVital"] = new Vector2 (25.24f, -7.94f),
+        ["FungleCamera"] = new Vector2(6.20f, 0.10f),
+        ["FungleVital"] = new Vector2(-2.50f, -9.80f)
     };
     public static float UsableDistance()
     {
@@ -36,6 +39,7 @@ class DisableDevice
             MapNames.Polus => 1.8f,
             //MapNames.Dleks => 1.5f,
             MapNames.Airship => 1.8f,
+            MapNames.Fungle => 1.8f,
             _ => 0.0f
         };
     }
@@ -94,6 +98,12 @@ class DisableDevice
                                 doComms |= Vector2.Distance(PlayerPos, DevicePos["AirshipCamera"]) <= UsableDistance();
                             if (Options.DisableAirshipVital.GetBool())
                                 doComms |= Vector2.Distance(PlayerPos, DevicePos["AirshipVital"]) <= UsableDistance();
+                            break;
+                        case 5:
+                            if (Options.DisableFungleCamera.GetBool())
+                                doComms |= Vector2.Distance(PlayerPos, DevicePos["FungleCamera"]) <= UsableDistance();
+                            if (Options.DisableFungleVital.GetBool())
+                                doComms |= Vector2.Distance(PlayerPos, DevicePos["FungleVital"]) <= UsableDistance();
                             break;
                     }
                 }
@@ -175,6 +185,12 @@ public class RemoveDisableDevicesPatch
                     consoles.DoIf(x => x.name == "task_cams", x => x.gameObject.GetComponent<BoxCollider2D>().enabled = false || ignore);
                 if (Options.DisableAirshipVital.GetBool())
                     consoles.DoIf(x => x.name == "panel_vitals", x => x.gameObject.GetComponent<CircleCollider2D>().enabled = false || ignore);
+                break;
+            case 5:
+                if (Options.DisableFungleCamera.GetBool())
+                    consoles.DoIf(x => x.name == "BinocularsSecurityConsole", x => x.gameObject.GetComponent<PolygonCollider2D>().enabled = false || ignore);
+                if (Options.DisableFungleCamera.GetBool())
+                    consoles.DoIf(x => x.name == "VitalsConsole", x => x.gameObject.GetComponent<BoxCollider2D>().enabled = false || ignore);
                 break;
         }
     }

--- a/Modules/DisableDevice.cs
+++ b/Modules/DisableDevice.cs
@@ -189,7 +189,7 @@ public class RemoveDisableDevicesPatch
             case 5:
                 if (Options.DisableFungleCamera.GetBool())
                     consoles.DoIf(x => x.name == "BinocularsSecurityConsole", x => x.gameObject.GetComponent<PolygonCollider2D>().enabled = false || ignore);
-                if (Options.DisableFungleCamera.GetBool())
+                if (Options.DisableFungleVital.GetBool())
                     consoles.DoIf(x => x.name == "VitalsConsole", x => x.gameObject.GetComponent<BoxCollider2D>().enabled = false || ignore);
                 break;
         }

--- a/Modules/OptionHolder.cs
+++ b/Modules/OptionHolder.cs
@@ -638,6 +638,9 @@ public static class Options
     public static OptionItem DisableAirshipRecordsAdmin;
     public static OptionItem DisableAirshipCamera;
     public static OptionItem DisableAirshipVital;
+    public static OptionItem DisableFungleDevices;
+    public static OptionItem DisableFungleCamera;
+    public static OptionItem DisableFungleVital;
     public static OptionItem DisableDevicesIgnoreConditions;
     public static OptionItem DisableDevicesIgnoreImpostors;
     public static OptionItem DisableDevicesIgnoreNeutrals;
@@ -2997,19 +3000,34 @@ public static class Options
         DisableAirshipVital = BooleanOptionItem.Create(22919, "DisableAirshipVital", false, TabGroup.GameSettings, false)
             .SetParent(DisableAirshipDevices)
             .SetGameMode(CustomGameMode.Standard);
-        DisableDevicesIgnoreConditions = BooleanOptionItem.Create(22920, "IgnoreConditions", false, TabGroup.GameSettings, false)
+        DisableFungleDevices = BooleanOptionItem.Create(22920, "DisableFungleDevices", false, TabGroup.GameSettings, false)
             .SetParent(DisableDevices)
             .SetGameMode(CustomGameMode.Standard);
-        DisableDevicesIgnoreImpostors = BooleanOptionItem.Create(22921, "IgnoreImpostors", false, TabGroup.GameSettings, false)
+        DisableFungleCamera = BooleanOptionItem.Create(22921, "DisableFungleCamera", false, TabGroup.GameSettings, false)
+            .SetParent(DisableFungleDevices)
+            .SetGameMode(CustomGameMode.Standard);
+        DisableFungleVital = BooleanOptionItem.Create(22922, "DisableFungleVital", false, TabGroup.GameSettings, false)
+            .SetParent(DisableFungleDevices)
+            .SetGameMode(CustomGameMode.Standard);
+        DisableDevicesIgnoreConditions = BooleanOptionItem.Create(22923, "IgnoreConditions", false, TabGroup.GameSettings, false)
+            .SetParent(DisableDevices)
+            .SetGameMode(CustomGameMode.Standard);
+        DisableDevicesIgnoreImpostors = BooleanOptionItem.Create(22924, "IgnoreImpostors", false, TabGroup.GameSettings, false)
+            .SetParent(DisableFungleDevices)
+            .SetGameMode(CustomGameMode.Standard);
+        DisableDevicesIgnoreConditions = BooleanOptionItem.Create(22925, "IgnoreConditions", false, TabGroup.GameSettings, false)
+            .SetParent(DisableDevices)
+            .SetGameMode(CustomGameMode.Standard);
+        DisableDevicesIgnoreImpostors = BooleanOptionItem.Create(22926, "IgnoreImpostors", false, TabGroup.GameSettings, false)
             .SetParent(DisableDevicesIgnoreConditions)
             .SetGameMode(CustomGameMode.Standard);
-        DisableDevicesIgnoreNeutrals = BooleanOptionItem.Create(22922, "IgnoreNeutrals", false, TabGroup.GameSettings, false)
+        DisableDevicesIgnoreNeutrals = BooleanOptionItem.Create(22927, "IgnoreNeutrals", false, TabGroup.GameSettings, false)
             .SetParent(DisableDevicesIgnoreConditions)
             .SetGameMode(CustomGameMode.Standard);
-        DisableDevicesIgnoreCrewmates = BooleanOptionItem.Create(22923, "IgnoreCrewmates", false, TabGroup.GameSettings, false)
+        DisableDevicesIgnoreCrewmates = BooleanOptionItem.Create(22928, "IgnoreCrewmates", false, TabGroup.GameSettings, false)
             .SetParent(DisableDevicesIgnoreConditions)
             .SetGameMode(CustomGameMode.Standard);
-        DisableDevicesIgnoreAfterAnyoneDied = BooleanOptionItem.Create(22924, "IgnoreAfterAnyoneDied", false, TabGroup.GameSettings, false)
+        DisableDevicesIgnoreAfterAnyoneDied = BooleanOptionItem.Create(22929, "IgnoreAfterAnyoneDied", false, TabGroup.GameSettings, false)
             .SetParent(DisableDevicesIgnoreConditions)
             .SetGameMode(CustomGameMode.Standard);
 

--- a/Modules/OptionHolder.cs
+++ b/Modules/OptionHolder.cs
@@ -3009,12 +3009,6 @@ public static class Options
         DisableFungleVital = BooleanOptionItem.Create(22922, "DisableFungleVital", false, TabGroup.GameSettings, false)
             .SetParent(DisableFungleDevices)
             .SetGameMode(CustomGameMode.Standard);
-        DisableDevicesIgnoreConditions = BooleanOptionItem.Create(22923, "IgnoreConditions", false, TabGroup.GameSettings, false)
-            .SetParent(DisableDevices)
-            .SetGameMode(CustomGameMode.Standard);
-        DisableDevicesIgnoreImpostors = BooleanOptionItem.Create(22924, "IgnoreImpostors", false, TabGroup.GameSettings, false)
-            .SetParent(DisableFungleDevices)
-            .SetGameMode(CustomGameMode.Standard);
         DisableDevicesIgnoreConditions = BooleanOptionItem.Create(22925, "IgnoreConditions", false, TabGroup.GameSettings, false)
             .SetParent(DisableDevices)
             .SetGameMode(CustomGameMode.Standard);

--- a/Resources/Lang/en_US.json
+++ b/Resources/Lang/en_US.json
@@ -1222,6 +1222,7 @@
   "DisablePolusVital": "Disable Vitals",
   "DisableAirshipVital": "Disable Vitals",
   "DisableFungleVital": "Disable Vitals",
+  "DisableFungleCamera": "Disable Binoculars",
   "IgnoreConditions": "Ignore Conditions",
   "IgnoreImpostors": "Ignore <color=#ff1919>Impostors</color>",
   "IgnoreNeutrals": "Ignore <color=#7f8c8d>Neutrals</color>",

--- a/Roles/Crewmate/Monitor.cs
+++ b/Roles/Crewmate/Monitor.cs
@@ -90,6 +90,12 @@ internal class Monitor
                         if (!Options.DisableAirshipVital.GetBool())
                             Vital |= Vector2.Distance(PlayerPos, DisableDevice.DevicePos["AirshipVital"]) <= DisableDevice.UsableDistance();
                         break;
+                    case 5:
+                        if (!Options.DisableFungleCamera.GetBool())
+                            Camera |= Vector2.Distance(PlayerPos, DisableDevice.DevicePos["FungleCamera"]) <= DisableDevice.UsableDistance();
+                        if (!Options.DisableFungleVital.GetBool())
+                            Vital |= Vector2.Distance(PlayerPos, DisableDevice.DevicePos["FungleVital"]) <= DisableDevice.UsableDistance();
+                        break;
                 }
             }
             catch (Exception ex)

--- a/Roles/Impostor/AntiAdminer.cs
+++ b/Roles/Impostor/AntiAdminer.cs
@@ -89,6 +89,12 @@ internal class AntiAdminer
                         if (!Options.DisableAirshipVital.GetBool())
                             Vital |= Vector2.Distance(PlayerPos, DisableDevice.DevicePos["AirshipVital"]) <= DisableDevice.UsableDistance();
                         break;
+                    case 5:
+                        if (!Options.DisableFungleCamera.GetBool())
+                            Camera |= Vector2.Distance(PlayerPos, DisableDevice.DevicePos["FungleCamera"]) <= DisableDevice.UsableDistance();
+                        if (!Options.DisableFungleVital.GetBool())
+                            Vital |= Vector2.Distance(PlayerPos, DisableDevice.DevicePos["FungleVital"]) <= DisableDevice.UsableDistance();
+                        break;
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
This pull request is for the Among Us v2023.10.24 pull request support ( #133 )

This adds the "Disable Devices For Fungle" setting and "Disable Vitals" and "Disable Binoculars" sub settings for it
This also adds the Anti Adminer and Monitor possibility to detect Binoculars and Vitals usage on Fungle