### PR TITLE
Trickster improvement and cyber incompatible with Doppelganger

### DIFF
--- a/Modules/CustomRolesHelper.cs
+++ b/Modules/CustomRolesHelper.cs
@@ -1095,6 +1095,8 @@ static class CustomRolesHelper
                 break;
 
             case CustomRoles.Cyber:
+                if (pc.Is(CustomRoles.Doppelganger))
+                    return false;
                 if ((pc.GetCustomRole().IsCrewmate() && !Options.CrewCanBeCyber.GetBool()) 
                     || (pc.GetCustomRole().IsNeutral() && !Options.NeutralCanBeCyber.GetBool()) 
                     || (pc.GetCustomRole().IsImpostor() && !Options.ImpCanBeCyber.GetBool()))

--- a/Patches/PlayerControlPatch.cs
+++ b/Patches/PlayerControlPatch.cs
@@ -1339,7 +1339,8 @@ class MurderPlayerPatch
             killer.TrapperKilled(target);
 
         Main.AllKillers.Remove(killer.PlayerId);
-        Main.AllKillers.Add(killer.PlayerId, Utils.GetTimeStamp());
+        if (!killer.Is(CustomRoles.Trickster))
+            Main.AllKillers.Add(killer.PlayerId, Utils.GetTimeStamp());
 
         switch (target.GetCustomRole())
         {

--- a/Roles/Crewmate/Reverie.cs
+++ b/Roles/Crewmate/Reverie.cs
@@ -69,7 +69,7 @@ public static class Reverie
         if (killer == null || target == null) return;
         if (!IsEnable || !killer.Is(CustomRoles.Reverie)) return;
         float kcd;
-        if (!target.GetCustomRole().IsCrewmate()) kcd = NowCooldown[killer.PlayerId] - ReduceKillCooldown.GetFloat();
+        if (!target.GetCustomRole().IsCrewmate() && !target.Is(CustomRoles.Trickster)) kcd = NowCooldown[killer.PlayerId] - ReduceKillCooldown.GetFloat();
         else kcd = NowCooldown[killer.PlayerId] + IncreaseKillCooldown.GetFloat();
         NowCooldown[killer.PlayerId] = Math.Clamp(kcd, MinKillCooldown.GetFloat(), MaxKillCooldown.GetFloat());
         killer.ResetKillCooldown();


### PR DESCRIPTION
1. Reverie killing them increases cooldown
2. Always shows as a check mark for witness
3. made cyber incompatible with Doppelgange