### PR TITLE
Update EAC

### DIFF
--- a/Modules/ChatManager.cs
+++ b/Modules/ChatManager.cs
@@ -191,7 +191,6 @@ namespace TOHE.Modules.ChatManager
                 {
                     senderPlayer.Revive();
                 }
-
                 DestroyableSingleton<HudManager>.Instance.Chat.AddChat(senderPlayer, senderMessage);
                 var writer = CustomRpcSender.Create("MessagesToSend", SendOption.None);
 

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -1332,7 +1332,7 @@ class MeetingHudOnDestroyPatch
             Main.AllPlayerControls.Do(pc => RandomSpawn.CustomNetworkTransformPatch.NumOfTP[pc.PlayerId] = 0);
 
             Main.LastVotedPlayerInfo = null;
-            EAC.MeetingTimes = 0;
+            EAC.MeetingTimes = new();
         }
     }
 }

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -1333,6 +1333,7 @@ class MeetingHudOnDestroyPatch
 
             Main.LastVotedPlayerInfo = null;
             EAC.MeetingTimes = new();
+            EAC.SabotageWhiteList = new();
         }
     }
 }

--- a/Patches/PlayerControlPatch.cs
+++ b/Patches/PlayerControlPatch.cs
@@ -1784,6 +1784,50 @@ class ReportDeadBodyPatch
 
         Logger.Info($"{__instance.GetNameWithRole()} => {target?.Object?.GetNameWithRole() ?? "null"}", "ReportDeadBody");
 
+        if (AmongUsClient.Instance.AmHost)
+        {
+            if (EAC.MeetingTimes.TryGetValue(__instance.PlayerId, out int meetingtimes))
+            {
+                EAC.MeetingTimes[__instance.PlayerId] = meetingtimes + 1;
+            }
+            else EAC.MeetingTimes.Add(__instance.PlayerId, 1);
+
+            if (!GameStates.IsInGame)
+            {
+                EAC.WarnHost();
+                EAC.Report(__instance, "非法报告尸体A");
+                EAC.TempBanCheat(__instance, "非法报告尸体A");
+                Logger.Fatal($"玩家【{__instance.GetClientId()}:{__instance.GetRealName()}】非法报告尸体A，已驳回", "EAC");
+                return false;
+            }
+
+            if (EAC.MeetingTimes[__instance.PlayerId] >= 7)
+            {
+                EAC.WarnHost();
+                EAC.Report(__instance, "非法报告尸体B");
+                EAC.TempBanCheat(__instance, "非法报告尸体B");
+                Logger.Fatal($"玩家【{__instance.GetClientId()}:{__instance.GetRealName()}】非法报告尸体B，已驳回", "EAC");
+                return false;
+            } //Normal a single can only be reported by a player once
+
+            if (GameStates.IsMeeting && EAC.MeetingTimes[__instance.PlayerId] >= 3)
+            {
+                EAC.WarnHost();
+                EAC.Report(__instance, "非法报告尸体B");
+                EAC.TempBanCheat(__instance, "非法报告尸体B");
+                Logger.Fatal($"玩家【{__instance.GetClientId()}:{__instance.GetRealName()}】非法报告尸体B，已驳回", "EAC");
+                return false;
+            }
+
+            if (target != null && !target.IsDead && target.GetCustomRole() != CustomRoles.Paranoia)
+            {
+                EAC.WarnHost();
+                EAC.Report(__instance, "非法报告尸体C");
+                Logger.Fatal($"玩家【{__instance.GetClientId()}:{__instance.GetRealName()}】非法报告尸体C，已驳回", "EAC");
+                return false;
+            }
+        }
+
         foreach (var kvp in Main.PlayerStates)
         {
             var pc = Utils.GetPlayerById(kvp.Key);

--- a/Patches/SabotageSystemPatch.cs
+++ b/Patches/SabotageSystemPatch.cs
@@ -281,11 +281,10 @@ public class SabotageSystemPatch
 
         private static bool Prefix([HarmonyArgument(0)] PlayerControl player, [HarmonyArgument(1)] MessageReader msgReader)
         {
-            byte systemtype, amount;
+            byte systemtype;
             {
                 var newReader = MessageReader.Get(msgReader);
                 systemtype = newReader.ReadByte();
-                amount = newReader.ReadByte();
                 newReader.Recycle();
             }
             var nextSabotage = (SystemTypes)systemtype;
@@ -295,13 +294,13 @@ public class SabotageSystemPatch
                 return false;
             }
 
-            Logger.Info("Sabotage" + ", PlayerName: " + player.GetNameWithRole() + ", SabotageType: " + nextSabotage.ToString() + ", amount: " + amount.ToString(), "SabotageSystemType");
-            if (EAC.SabotageSystemCheck(player, nextSabotage, amount))
+            Logger.Info("Sabotage" + ", PlayerName: " + player.GetNameWithRole() + ", SabotageType: " + nextSabotage.ToString(), "SabotageSystemType");
+            if (EAC.SabotageSystemCheck(player, nextSabotage, 0))
             {
                 Logger.Info("EAC action patch Sabotage", "SabotageSystemType.UpdateSystem");
                 return false;
             }
-
+            if (CanSabotage(player, nextSabotage) && !player.AmOwner && !player.IsModClient()) EAC.SabotageWhiteList.Add(player.PlayerId, nextSabotage);
             return CanSabotage(player, nextSabotage);
         }
         private static bool CanSabotage(PlayerControl player, SystemTypes systemType)

--- a/Patches/SabotageSystemPatch.cs
+++ b/Patches/SabotageSystemPatch.cs
@@ -281,20 +281,26 @@ public class SabotageSystemPatch
 
         private static bool Prefix([HarmonyArgument(0)] PlayerControl player, [HarmonyArgument(1)] MessageReader msgReader)
         {
-            byte amount;
+            byte systemtype, amount;
             {
                 var newReader = MessageReader.Get(msgReader);
+                systemtype = newReader.ReadByte();
                 amount = newReader.ReadByte();
                 newReader.Recycle();
             }
-            var nextSabotage = (SystemTypes)amount;
+            var nextSabotage = (SystemTypes)systemtype;
 
             if (Options.DisableSabotage.GetBool())
             {
                 return false;
             }
 
-            Logger.Info("Sabotage" + ", PlayerName: " + player.GetNameWithRole() + ", SabotageType: " + nextSabotage.ToString(), "RepairSystem");
+            Logger.Info("Sabotage" + ", PlayerName: " + player.GetNameWithRole() + ", SabotageType: " + nextSabotage.ToString() + ", amount: " + amount.ToString(), "SabotageSystemType");
+            if (EAC.SabotageSystemCheck(player, nextSabotage, amount))
+            {
+                Logger.Info("EAC action patch Sabotage", "SabotageSystemType.UpdateSystem");
+                return false;
+            }
 
             return CanSabotage(player, nextSabotage);
         }

--- a/Patches/ShipStatusPatch.cs
+++ b/Patches/ShipStatusPatch.cs
@@ -63,6 +63,12 @@ class RepairSystemPatch
 
         if (!AmongUsClient.Instance.AmHost) return true;
 
+        if (EAC.SabotageSystemCheck(player, systemType, amount))
+        {
+            Logger.Info("EAC action patch sabotage", "ShipStatus.UpdateSystem");
+            return false;
+        } //IDK why return false here can not patch the sabotage
+
         if (Options.DisableSabotage.GetBool() && systemType == SystemTypes.Sabotage)
         {
             return false;
@@ -80,7 +86,6 @@ class RepairSystemPatch
         {
             return false;
         }
-
         // Fast fix critical saboatge
         switch (player.GetCustomRole())
         {

--- a/Patches/ShipStatusPatch.cs
+++ b/Patches/ShipStatusPatch.cs
@@ -54,7 +54,7 @@ class RepairSystemPatch
         [HarmonyArgument(1)] PlayerControl player,
         [HarmonyArgument(2)] byte amount)
     {
-        Logger.Msg("SystemType: " + systemType.ToString() + ", PlayerName: " + player.GetNameWithRole().RemoveHtmlTags() + ", amount: " + amount, "RepairSystem");
+        Logger.Msg("SystemType: " + systemType.ToString() + ", PlayerName: " + player.GetNameWithRole().RemoveHtmlTags() + ", amount: " + amount, "ShipStatus.UpdateSystem");
 
         if (RepairSender.enabled && AmongUsClient.Instance.NetworkMode != NetworkModes.OnlineGame)
         {


### PR DESCRIPTION
Add sabotage check for EAC
1. player with crew basis can not sabotage
2. player who send rpc to directly sabotage (amount 128 , 16, electric > 50) will be checked if it has pre send systemtypes.sabotage and agreed by host

Tommy can you pls help me with stuffs in sabotage patch?
I return false in shipstatuspatch but sabotage is still triggered by malummenu
probably bcz it does not send systemtypes sabotage for host to check but amount 128 to directly sabotage