### PR TITLE
Remove overkiller latekill in afterreporttasks

### DIFF
--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -1185,6 +1185,11 @@ static class ExtendedPlayerControl
             Main.AllPlayerKillCooldown[player.PlayerId] = kcd;
             Logger.Info($"kill cd of player set to {Main.AllPlayerKillCooldown[player.PlayerId]}", "Antidote");
         }
+        if (Main.AllPlayerKillCooldown[player.PlayerId] == 0)
+        {
+            if (player.Is(CustomRoles.Chronomancer)) return;
+            Main.AllPlayerKillCooldown[player.PlayerId] = 0.3f;
+        }
     }
     public static bool IsNonCrewSheriff(this PlayerControl sheriff)
     {

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -1026,7 +1026,7 @@ static class ExtendedPlayerControl
                 Pursuer.SetKillCooldown(player.PlayerId);
                 break;
             case CustomRoles.FFF:
-                Main.AllPlayerKillCooldown[player.PlayerId] = 0f;
+                Main.AllPlayerKillCooldown[player.PlayerId] = 1f;
                 break;
             case CustomRoles.Medusa:
                 Medusa.SetKillCooldown(player.PlayerId);

--- a/Patches/ClientOptionsPatch.cs
+++ b/Patches/ClientOptionsPatch.cs
@@ -57,7 +57,7 @@ public static class OptionsMenuBehaviourStartPatch
         }
         if (HorseMode == null || HorseMode.ToggleButton == null)
         {
-            HorseMode = ClientOptionItem.Create("HorseMode", Main.HorseMode, __instance, () => HorseModePatch.isHorseMode = !HorseModePatch.isHorseMode);
+            HorseMode = ClientOptionItem.Create("HorseMode", Main.HorseMode, __instance);
         }
         if (EnableGM == null || EnableGM.ToggleButton == null)
         {

--- a/Patches/MainMenuManagerPatch.cs
+++ b/Patches/MainMenuManagerPatch.cs
@@ -304,10 +304,9 @@ public static class MainMenuManagerPatch
 [HarmonyPatch(typeof(Constants), nameof(Constants.ShouldHorseAround))]
 public static class HorseModePatch
 {
-    public static bool isHorseMode = false;
     public static bool Prefix(ref bool __result)
     {
-        __result = isHorseMode;
+        __result = Main.HorseMode.Value;
         return false;
     }
 }

--- a/Patches/PlayerControlPatch.cs
+++ b/Patches/PlayerControlPatch.cs
@@ -2297,6 +2297,7 @@ class ReportDeadBodyPatch
         Main.Lighter.Clear();
         Main.AllKillers.Clear();
         Main.GodfatherTarget.Clear();
+        OverKiller.MurderTargetLateTask.Clear();
 
         if (Options.BombsClearAfterMeeting.GetBool())
         {


### PR DESCRIPTION
Seems like during the time someone reported and meeting hud did not appear,
the game is still in task and overkiller late kill still functions, showing bodies after meeting

Also changed FFF killcooldown to 1. 
Force set those 0 kcd to 0.3f. Allowing kcd to be 0 simply means more useless checkmurder rpc
if there are really roles that must use 0 kcd, exclude it from the check

Hope this could ease the issue

Also fix horse mode value set, I added bugs with little brain