### PR TITLE
Fix OIIAI neutral assign

### DIFF
--- a/Modules/CustomRolesHelper.cs
+++ b/Modules/CustomRolesHelper.cs
@@ -254,6 +254,22 @@ static class CustomRolesHelper
             _ => RoleTypes.GuardianAngel
         };
     }
+
+    public static bool HasImpKillButton(this PlayerControl player, bool considerVanillaShift = false)
+    {
+        if (player == null) return false;
+        var customRole = player.GetCustomRole();
+        bool hostSideHasKillButton = customRole.GetDYRole() == RoleTypes.Impostor || customRole.GetVNRole() == CustomRoles.Impostor || customRole.GetVNRole() == CustomRoles.Shapeshifter;
+
+        if (player.IsModClient() || (!considerVanillaShift && !player.IsModClient()))
+            return hostSideHasKillButton;
+
+        bool vanillaSideHasKillButton = Main.ErasedRoleStorage.TryGetValue(player.PlayerId, out var erasedRole) ?
+                                         (erasedRole.GetDYRole() == RoleTypes.Impostor || erasedRole.GetVNRole() == CustomRoles.Impostor || erasedRole.GetVNRole() == CustomRoles.Shapeshifter) : hostSideHasKillButton;
+
+        return vanillaSideHasKillButton;
+    }
+    //This is a overall check for vanilla clients to see if they are imp basis
     public static bool IsAdditionRole(this CustomRoles role)
     {
         return role is

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -213,12 +213,10 @@ static class ExtendedPlayerControl
     public static void SetKillCooldown(this PlayerControl player, float time = -1f, PlayerControl target = null, bool forceAnime = false)
     {
         if (player == null) return;
-        if (!Main.ErasedRoleStorage.ContainsKey(player.PlayerId))
-        {
-            if (!player.CanUseKillButton()) return;
-        }
-        else if (!HasKillButton(role: Main.ErasedRoleStorage[player.PlayerId]))
-            return;
+
+        if (!player.HasImpKillButton(considerVanillaShift: true)) return;
+        if (player.HasImpKillButton(false) && !player.CanUseKillButton()) return;
+
         if (target == null) target = player;
         if (time >= 0f) Main.AllPlayerKillCooldown[player.PlayerId] = time * 2;
         else Main.AllPlayerKillCooldown[player.PlayerId] *= 2;
@@ -1158,13 +1156,6 @@ static class ExtendedPlayerControl
             case CustomRoles.EvilMini:
                 Main.AllPlayerKillCooldown[player.PlayerId] = Mini.GetKillCoolDown();
                 break;
-            case CustomRoles.CrewmateTOHE:
-            case CustomRoles.EngineerTOHE:
-            case CustomRoles.ScientistTOHE:
-            case CustomRoles.GuardianAngelTOHE:
-                Main.AllPlayerKillCooldown[player.PlayerId] = 300f;
-                break;
-                //Vanilla imp and ss is done at the beginning of the function
         }
         if (player.PlayerId == LastImpostor.currentId)
             LastImpostor.SetKillCooldown();
@@ -1185,6 +1176,8 @@ static class ExtendedPlayerControl
             Main.AllPlayerKillCooldown[player.PlayerId] = kcd;
             Logger.Info($"kill cd of player set to {Main.AllPlayerKillCooldown[player.PlayerId]}", "Antidote");
         }
+        if (!player.HasImpKillButton(considerVanillaShift: false))
+            Main.AllPlayerKillCooldown[player.PlayerId] = 300f;
         if (Main.AllPlayerKillCooldown[player.PlayerId] == 0)
         {
             if (player.Is(CustomRoles.Chronomancer)) return;

--- a/Modules/GameState.cs
+++ b/Modules/GameState.cs
@@ -57,6 +57,7 @@ public class PlayerState
     {
         MainRole = role;
         countTypes = role.GetCountTypes();
+        var pc = Utils.GetPlayerById(PlayerId);
         if (role == CustomRoles.DarkHide)
         {
             if (!DarkHide.SnatchesWin.GetBool())
@@ -77,6 +78,23 @@ public class PlayerState
             if (!Options.ArsonistCanIgniteAnytime.GetBool())
             {
                 countTypes = CountTypes.Crew;
+            }
+        }
+        if (role == CustomRoles.Opportunist)
+        {
+            if (AmongUsClient.Instance.AmHost)
+            {
+                if (!pc.HasImpKillButton(considerVanillaShift: true))
+                {
+                    var taskstate = pc.GetPlayerTaskState();
+                    if (taskstate != null)
+                    {
+                        GameData.Instance.RpcSetTasks(pc.PlayerId, new byte[0]);
+                        taskstate.CompletedTasksCount = 0;
+                        taskstate.AllTasksCount = pc.Data.Tasks.Count;
+                        taskstate.hasTasks = true;
+                    }
+                }
             }
         }
     }

--- a/Roles/AddOns/Common/Oiiai.cs
+++ b/Roles/AddOns/Common/Oiiai.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using AmongUs.GameOptions;
+using System.Collections.Generic;
 using TOHE.Roles.Neutral;
 using static TOHE.Translator;
 
@@ -76,20 +77,31 @@ namespace TOHE.Roles.AddOns.Common
                 return;
             }
 
-            if (!killer.GetCustomRole().IsNK())
+            if (!killer.GetCustomRole().IsNeutral())
             {
                 //Use eraser here LOL
                 killer.RpcSetCustomRole(CustomRolesHelper.GetErasedRole(killer.GetCustomRole().GetRoleTypes(), killer.GetCustomRole()));
+                Logger.Info($"Oiiai {killer.GetNameWithRole()} with eraser assign.", "Oiiai");
             }
             else
             {
-                int changeValue = ChangeNeutralRole.GetValue();
+                if (killer.HasImpKillButton())
+                {
+                    int changeValue = ChangeNeutralRole.GetValue();
 
-                if (changeValue != 0) { 
-                //Typically only NK tiggers this
-                    killer.RpcSetCustomRole(NRoleChangeRoles[changeValue-1]);
-                    if (changeValue == 1) Amnesiac.Add(killer.PlayerId);
-                    else if (changeValue == 2) Imitator.Add(killer.PlayerId);
+                    if (changeValue != 0)
+                    {
+                        killer.RpcSetCustomRole(NRoleChangeRoles[changeValue - 1]);
+                        if (changeValue == 1) Amnesiac.Add(killer.PlayerId);
+                        else if (changeValue == 2) Imitator.Add(killer.PlayerId);
+
+                        Logger.Info($"Oiiai {killer.GetNameWithRole()} with Neutrals with kill button assign.", "Oiiai");
+                    }
+                }
+                else
+                {
+                    killer.RpcSetCustomRole(CustomRoles.Opportunist);
+                    Logger.Info($"Oiiai {killer.GetNameWithRole()} with Neutrals without kill button assign.", "Oiiai");
                 }
             }
             killer.ResetKillCooldown();
@@ -97,9 +109,10 @@ namespace TOHE.Roles.AddOns.Common
             killer.Notify(GetString("LostRoleByOiiai"));
             Logger.Info($"{killer.GetRealName()} was OIIAIed", "Oiiai");
         }
+
         private static bool CanGetOiiaied(PlayerControl player)
         {
-            if (player.GetCustomRole().IsNK() && ChangeNeutralRole.GetValue() == 0) return false;
+            if (player.GetCustomRole().IsNeutral() && ChangeNeutralRole.GetValue() == 0) return false;
             if (player.Is(CustomRoles.Loyal)) return false;
 
             return true;


### PR DESCRIPTION
Bug: 
Neutrals but not NK will be erased to Crewmate

Solution:
Add function HasImpKillButton to decide whether the player has kill button
if they do, use NK assign
If they dont, assign opportunitist

Also reset opportunitist tasks upon assigning