### PR TITLE
fix exile chat spam and option to not do it

### DIFF
--- a/Modules/ChatManager.cs
+++ b/Modules/ChatManager.cs
@@ -134,7 +134,7 @@ namespace TOHE.Modules.ChatManager
                 }
                 if (!player.IsAlive()) return;
                 message = msg;
-                Logger.Warn($"Logging msg : {message}","Checking Exile");
+                //Logger.Warn($"Logging msg : {message}","Checking Exile");
                 Dictionary<byte, string> newChatEntry = new()
                     {
                         { player.PlayerId, message }

--- a/Modules/ChatManager.cs
+++ b/Modules/ChatManager.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using TOHE.Roles.Impostor;
+using static TOHE.Translator;
 
 namespace TOHE.Modules.ChatManager
 {
@@ -124,11 +125,16 @@ namespace TOHE.Modules.ChatManager
             {
                 if (GameStates.IsExilling)
                 {
-                    Logger.Info($"死亡玩家嘗試於逐出畫面傳送訊息但遭到阻擋", "ChatManager");
-                    new LateTask(() => { SendPreviousMessagesToAll(); }, 7f);
+                    if (Options.HideExileChat.GetBool()) 
+                    { 
+                        Logger.Info($"Message sent in exiling screen, spamming the chat", "ChatManager");
+                        _ = new LateTask(() => { SendPreviousMessagesToAll(); }, 0.3f);
+                    }
                     return;
                 }
+                if (!player.IsAlive()) return;
                 message = msg;
+                Logger.Warn($"Logging msg : {message}","Checking Exile");
                 Dictionary<byte, string> newChatEntry = new()
                     {
                         { player.PlayerId, message }
@@ -145,6 +151,48 @@ namespace TOHE.Modules.ChatManager
 
         public static void SendPreviousMessagesToAll()
         {
+            if (GameStates.IsExilling && chatHistory.Count < 20)
+            {
+                var firstAlivePlayer = Main.AllAlivePlayerControls.OrderBy(x => x.PlayerId).FirstOrDefault();
+                if (firstAlivePlayer == null) return;
+
+                var title = "<color=#aaaaff>" + GetString("DefaultSystemMessageTitle") + "</color>";
+                var name = firstAlivePlayer?.Data?.PlayerName;
+                string spamMsg = GetString("ExileSpamMsg");
+
+                for (int i = 0; i < 20 - chatHistory.Count; i++)
+                {
+                    int clientId = -1; //sendTo == byte.MaxValue ? -1 : Utils.GetPlayerById(sendTo).GetClientId();
+                    //if (clientId == -1)
+                    //{
+                    firstAlivePlayer.SetName(title);
+                    DestroyableSingleton<HudManager>.Instance.Chat.AddChat(firstAlivePlayer, spamMsg);
+                    firstAlivePlayer.SetName(name);
+                    //}
+                    var writer = CustomRpcSender.Create("MessagesToSend", SendOption.None);
+                    writer.StartMessage(clientId);
+                    writer.StartRpc(firstAlivePlayer.NetId, (byte)RpcCalls.SetName)
+                        .Write(title)
+                        .EndRpc();
+                    writer.StartRpc(firstAlivePlayer.NetId, (byte)RpcCalls.SendChat)
+                        .Write(spamMsg)
+                        .EndRpc();
+                    writer.StartRpc(firstAlivePlayer.NetId, (byte)RpcCalls.SetName)
+                        .Write(name)
+                        .EndRpc();
+                    writer.EndMessage();
+                    writer.SendMessage();
+                    //DestroyableSingleton<HudManager>.Instance.Chat.AddChat(firstAlivePlayer, spamMsg);
+                    //var writer = CustomRpcSender.Create("MessagesToSend", SendOption.None);
+
+                    //writer.StartMessage(-1);
+                    //writer.StartRpc(firstAlivePlayer.NetId, (byte)RpcCalls.SendChat)
+                    //    .Write(spamMsg)
+                    //    .EndRpc()
+                    //    .EndMessage()
+                    //    .SendMessage();
+                }
+            }
             //var rd = IRandom.Instance;
             //CustomRoles[] roles = (CustomRoles[])Enum.GetValues(typeof(CustomRoles));
             //string[] specialTexts = new string[] { "bet", "bt", "guess", "gs", "shoot", "st", "赌", "猜", "审判", "tl", "判", "审", "trial" };
@@ -191,7 +239,6 @@ namespace TOHE.Modules.ChatManager
                 var senderMessage = entry[senderId];
                 var senderPlayer = Utils.GetPlayerById(senderId);
                 if (senderPlayer == null) continue;
-                if (GameStates.IsExilling) return;
 
                 var playerDead = !senderPlayer.IsAlive();
                 if (playerDead)

--- a/Modules/OptionHolder.cs
+++ b/Modules/OptionHolder.cs
@@ -850,6 +850,7 @@ public static class Options
     public static OptionItem AutoDisplayLastRoles;
     public static OptionItem AutoDisplayKillLog;
     public static OptionItem AutoDisplayLastResult;
+    public static OptionItem HideExileChat;
     public static OptionItem SuffixMode;
     public static OptionItem HideGameSettings;
     public static OptionItem FormatNameMode;
@@ -2942,6 +2943,9 @@ public static class Options
             .SetHeader(true);
         AutoDisplayLastRoles = BooleanOptionItem.Create(60280, "AutoDisplayLastRoles", true, TabGroup.SystemSettings, false);
         AutoDisplayLastResult = BooleanOptionItem.Create(60290, "AutoDisplayLastResult", true, TabGroup.SystemSettings, false);
+
+        HideExileChat = BooleanOptionItem.Create(60295, "HideExileChat", true, TabGroup.SystemSettings, false)
+            .SetHeader(true);
 
         SuffixMode = StringOptionItem.Create(60300, "SuffixMode", suffixModes, 0, TabGroup.SystemSettings, true)
             .SetHeader(true);

--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -50,6 +50,7 @@ internal class ChatCommands
 
         //if (text.Length >= 3) if (text[..2] == "/r" && text[..3] != "/rn" && text[..3] != "/rs") args[0] = "/r";
         if (text.Length >= 4) if (text[..3] == "/up") args[0] = "/up";
+
         if (GuessManager.GuesserMsg(PlayerControl.LocalPlayer, text)) goto Canceled;
         if (Judge.TrialMsg(PlayerControl.LocalPlayer, text)) goto Canceled;
         if (President.EndMsg(PlayerControl.LocalPlayer, text)) goto Canceled;

--- a/Resources/Lang/en_US.json
+++ b/Resources/Lang/en_US.json
@@ -1219,6 +1219,10 @@
   "AutoDisplayKillLog": "Display Kill-log",
   "AutoDisplayLastRoles": "Display Last Roles",
   "AutoDisplayLastResult": "Auto Display Last Result",
+
+  "HideExileChat": "Hide exile (lava) chat",
+  "ExileSpamMsg": "Someone is trying to be a smart ass by lava chatting",
+
   "EnableYTPlan": "Enable Youtuber Plan",
   "KickLowLevelPlayer": "Kick players whose level is lower than",
   "TempBanLowLevelPlayer": "Temporarily ban low-level players",
@@ -2639,7 +2643,7 @@
 
   "RandCommandInfo": "<b>This Command can only be used when in lobby or after you die.</b>\n\ntype <b>/rand X Y</b> to get a number between X and Y, inclusive. \nX and Y can be any number between 0 and 2147483647, including both numbers.\nX must be less than Y.\n\nExample:- <b>/rand 0 99</b>",
   "RandResult": "Congratulations, your random number is {0}! Wasn't that fun?",
-  
+
   "ChanceToMiss": "Chance to miss a kill",
   "ImpCanBeClumsy": "<color=#ff1919>Impostors</color> can become Clumsy",
   "NeutralCanBeClumsy": "<color=#7f8c8d>Neutral Killers</color> can become Clumsy",


### PR DESCRIPTION
1. fixed, and improved exile chat spam when no messages were sent in meeting
2.  added a setting to not spam the chat.