### PR TITLE
Fix Solsticer Bug

### DIFF
--- a/Modules/GuessManager.cs
+++ b/Modules/GuessManager.cs
@@ -204,6 +204,12 @@ public static class GuessManager
                     else pc.ShowPopUp(GetString("EGGuessMax"));
                     return true;
                 }
+                if (pc.Is(CustomRoles.Solsticer) && !Solsticer.CanGuess)
+                {
+                    if (!isUI) Utils.SendMessage(GetString("SolsticerGuessMax"), pc.PlayerId);
+                    else pc.ShowPopUp(GetString("SolsticerGuessMax"));
+                    return true;
+                }
                 if (pc.Is(CustomRoles.Phantom) && !Options.PhantomCanGuess.GetBool())
                 {
                     if (!isUI) Utils.SendMessage(GetString("GuessDisabled"), pc.PlayerId);
@@ -669,6 +675,13 @@ public static class GuessManager
 
                         return true;
                     }
+                }
+
+                if (dp.Is(CustomRoles.Solsticer))
+                {
+                    Solsticer.CanGuess = false;
+                    _ = new LateTask(() => { Utils.SendMessage(GetString("SolsticerMisGuessed"), dp.PlayerId, Utils.ColorString(Utils.GetRoleColor(CustomRoles.Solsticer), GetString("GuessKillTitle")), true); }, 0.6f, "Solsticer MisGuess Msg");
+                    return true;
                 }
 
                 string Name = dp.GetRealName();
@@ -1174,6 +1187,8 @@ public static class GuessManager
                     //     or CustomRoles.Reflective
                     or CustomRoles.GuardianAngelTOHE
                     or CustomRoles.Solsticer
+                    or CustomRoles.GuardianAngel
+                    or CustomRoles.Killer
                     ) continue;
 
                 CreateRole(role);

--- a/Modules/GuessManager.cs
+++ b/Modules/GuessManager.cs
@@ -204,7 +204,7 @@ public static class GuessManager
                     else pc.ShowPopUp(GetString("EGGuessMax"));
                     return true;
                 }
-                if (pc.Is(CustomRoles.Solsticer) && !Solsticer.CanGuess)
+                if (pc.Is(CustomRoles.Solsticer) && (!Solsticer.CanGuess || !Solsticer.SolsticerCanGuess.GetBool()))
                 {
                     if (!isUI) Utils.SendMessage(GetString("SolsticerGuessMax"), pc.PlayerId);
                     else pc.ShowPopUp(GetString("SolsticerGuessMax"));
@@ -1189,6 +1189,12 @@ public static class GuessManager
                     or CustomRoles.Solsticer
                     or CustomRoles.GuardianAngel
                     or CustomRoles.Killer
+                    or CustomRoles.Mini
+                    or CustomRoles.Onbound
+                    or CustomRoles.Rebound
+                    or CustomRoles.LastImpostor
+                    or CustomRoles.Mare
+                    or CustomRoles.Cyber
                     ) continue;
 
                 CreateRole(role);

--- a/Patches/PlayerControlPatch.cs
+++ b/Patches/PlayerControlPatch.cs
@@ -2377,6 +2377,7 @@ class ReportDeadBodyPatch
         if (Jailer.IsEnable) Jailer.OnReportDeadBody();
         if (Romantic.IsEnable) Romantic.OnReportDeadBody();
         if (Captain.IsEnable) Captain.OnReportDeadBody();
+        Solsticer.patched = false;
 
 
         // if (Councillor.IsEnable) Councillor.OnReportDeadBody();

--- a/Resources/Lang/en_US.json
+++ b/Resources/Lang/en_US.json
@@ -3534,6 +3534,8 @@
   "GuessSolsticer": "Sorry, but you can not guess Solsticer!",
   "VoteSolsticer": "Sorry, but you can not vote Solsticer!",
   "SolsticerTasksReset": "Your tasks get reset!",
+  "SolsticerMisGuessed": "You just misguessed! So you are no longer allowed to guess.",
+  "SolsticerGuessMax": "Because you already misguessed, you are no longer allowed to guess.",
 
   "VoteDead": "Sorry, but the player you just voted is already died, so your vote is returned."
 }

--- a/Roles/Neutral/Solsticer.cs
+++ b/Roles/Neutral/Solsticer.cs
@@ -24,6 +24,7 @@ namespace TOHE.Roles.Neutral
         public static bool patched;
         public static int AddShortTasks;
         public static bool warningActived;
+        public static bool CanGuess;
         public static string MurderMessage;
         public static void SetupCustomOption()
         {
@@ -51,6 +52,7 @@ namespace TOHE.Roles.Neutral
             patched = false;
             AddShortTasks = 0;
             Count = 0;
+            CanGuess = true;
             MurderMessage = "";
         }
         
@@ -117,7 +119,6 @@ namespace TOHE.Roles.Neutral
             if (!GameStates.IsMeeting)
             {
                 Utils.RpcTeleport(target, ExtendedPlayerControl.GetBlackRoomPosition());
-                Main.AllPlayerSpeed[target.PlayerId] = 0.5f;
                 ReportDeadBodyPatch.CanReport[target.PlayerId] = false;
                 NameNotifyManager.Notify(target, string.Format(GetString("SolsticerMurdered"), killer.GetRealName()));
                 target.RpcGuardAndKill();
@@ -165,8 +166,16 @@ namespace TOHE.Roles.Neutral
                 if (dis < 1f)
                     return;
 
-                if (GameStates.IsMeeting) return;
+                if (GameStates.IsMeeting || !patched) return;
                 pc.RpcTeleport(pos);
+            }
+            else if (GameStates.IsInGame)
+            {
+                if (Main.AllPlayerSpeed[pc.PlayerId] != SolsticerSpeed.GetFloat())
+                {
+                    Main.AllPlayerSpeed[pc.PlayerId] = SolsticerSpeed.GetFloat();
+                    pc.MarkDirtySettings();
+                }
             }
         }
         public static void SendRPC()


### PR DESCRIPTION
1. Fix Solsticer appears out of map after meeting
2. Remove Solsticer slow speed
    bcz Solsticer is not dying, we dont need to set its speed slow like pelican, Just tp it out of map is enough
3. Solsticer now can not die of misguess, instead it will no longer be able to guess

4. Hide GAngle and FFAKiller and some obvious roles from guesser gui