### PR TITLE
Fix system messages sometimes wont appear after rejoining lobby

### DIFF
--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -31,6 +31,7 @@ internal class ChatCommands
 
     public static bool Prefix(ChatController __instance)
     {
+        if (__instance.quickChatField.visible) return true;
         if (__instance.freeChatField.textArea.text == "") return false;
         __instance.timeSinceLastMessage = 3f;
         var text = __instance.freeChatField.textArea.text;
@@ -2218,9 +2219,16 @@ class ChatUpdatePatch
     public static bool DoBlockChat = false;
     public static void Postfix(ChatController __instance)
     {
+        __instance.freeChatField.textArea.AllowPaste = true;
         if (!AmongUsClient.Instance.AmHost || !Main.MessagesToSend.Any() || (Main.MessagesToSend[0].Item2 == byte.MaxValue && Main.MessageWait.Value > __instance.timeSinceLastMessage)) return;
         if (DoBlockChat) return;
-        var player = Main.AllAlivePlayerControls.OrderBy(x => x.PlayerId).FirstOrDefault();
+        var player = PlayerControl.LocalPlayer;
+        if (!GameStates.IsLobby)
+        {
+            player = Main.AllAlivePlayerControls.OrderBy(x => x.PlayerId).FirstOrDefault()
+                     ?? Main.AllPlayerControls.OrderBy(x => x.PlayerId).FirstOrDefault()
+                     ?? player;
+        }
         if (player == null) return;
         (string msg, byte sendTo, string title) = Main.MessagesToSend[0];
         Main.MessagesToSend.RemoveAt(0);
@@ -2260,6 +2268,22 @@ internal class AddChatPatch
                 break;
         }
         if (!AmongUsClient.Instance.AmHost) return;
+    }
+}
+
+[HarmonyPatch(typeof(FreeChatInputField), nameof(FreeChatInputField.UpdateCharCount))]
+internal class UpdateCharCountPatch
+{
+    public static void Postfix(FreeChatInputField __instance)
+    {
+        int length = __instance.textArea.text.Length;
+        __instance.charCountText.SetText($"{length}/{__instance.textArea.characterLimit}");
+        if (length < (AmongUsClient.Instance.AmHost ? 888 : 250))
+            __instance.charCountText.color = Color.black;
+        else if (length < (AmongUsClient.Instance.AmHost ? 999 : 300))
+            __instance.charCountText.color = new Color(1f, 1f, 0f, 1f);
+        else
+            __instance.charCountText.color = Color.red;
     }
 }
 [HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.RpcSendChat))]

--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -2223,10 +2223,10 @@ class ChatUpdatePatch
         if (!AmongUsClient.Instance.AmHost || !Main.MessagesToSend.Any() || (Main.MessagesToSend[0].Item2 == byte.MaxValue && Main.MessageWait.Value > __instance.timeSinceLastMessage)) return;
         if (DoBlockChat) return;
         var player = PlayerControl.LocalPlayer;
-        if (!GameStates.IsLobby)
+        if (GameStates.IsInGame || player.Data.IsDead)
         {
-            player = Main.AllAlivePlayerControls.OrderBy(x => x.PlayerId).FirstOrDefault()
-                     ?? Main.AllPlayerControls.OrderBy(x => x.PlayerId).FirstOrDefault()
+            player = Main.AllAlivePlayerControls.ToArray().OrderBy(x => x.PlayerId).FirstOrDefault()
+                     ?? Main.AllPlayerControls.ToArray().OrderBy(x => x.PlayerId).FirstOrDefault()
                      ?? player;
         }
         if (player == null) return;

--- a/Patches/TextBoxPatch.cs
+++ b/Patches/TextBoxPatch.cs
@@ -1,0 +1,37 @@
+using HarmonyLib;
+using System.Collections.Generic;
+
+namespace TOHE.Patches;
+
+/* Originally by Kap. Reference: https://github.com/KARPED1EM/TownOfNext/blob/TONX/TONX/Patches/TextBoxPatch.cs */
+[HarmonyPatch(typeof(TextBoxTMP))]
+public class TextBoxPatch
+{
+    static Dictionary<string, string> replaceDic = new()
+            {
+                { "£¨", " (" },
+                { "£©", ") " },
+                { "£¬", ", " },
+                { "£º", ": " },
+                { "[", "¡¾" },
+                { "]", "¡¿" },
+                { "¡®", " '" },
+                { "¡¯", "' " },
+                { "¡°", " ''" },
+                { "¡±", "'' " },
+                { "£¡", "! " },
+            };
+    [HarmonyPatch(nameof(TextBoxTMP.SetText)), HarmonyPrefix]
+    public static bool ModifyCharacterLimit(TextBoxTMP __instance, [HarmonyArgument(0)] string input, [HarmonyArgument(1)] string inputCompo = "")
+    {
+        __instance.characterLimit = AmongUsClient.Instance.AmHost ? 999 : 300;
+        if (input.Length < 1) return true;
+        string before = input[^1..];
+        if (replaceDic.TryGetValue(before, out var after))
+        {
+            __instance.SetText(input.Replace(before, after));
+            return false;
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
1. Improve the sender selection of sendchat
2. Fix mods can not use Quick Chat (While quick chats is still covered by player names in lobby)
3. Change the characters limit for chats for modded (Thanks Kap for the code)