### PR TITLE
keeper dual vote and fix pixie bug

### DIFF
--- a/Patches/ExilePatch.cs
+++ b/Patches/ExilePatch.cs
@@ -49,6 +49,7 @@ class ExileControllerWrapUpPatch
         bool DecidedWinner = false;
         if (!AmongUsClient.Instance.AmHost) return;
         AntiBlackout.RestoreIsDead(doSend: false);
+        Pixie.CheckExileTarget(exiled);
 
         Logger.Info($"{!Collector.CollectorWin(false)}", "!Collector.CollectorWin(false)");
         Logger.Info($"{exiled != null}", "exiled != null");
@@ -156,7 +157,6 @@ class ExileControllerWrapUpPatch
                 DecidedWinner = false;
             }
 
-            Pixie.CheckExileTarget(exiled);
 
             if (CustomWinnerHolder.WinnerTeam != CustomWinner.Terrorist) Main.PlayerStates[exiled.PlayerId].SetDead();
 

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -114,9 +114,7 @@ class CheckForEndVotingPatch
                             case CustomRoles.Cleanser:
                                 Cleanser.OnVote(pc, voteTarget);
                                 break;
-                            case CustomRoles.Keeper:
-                                Keeper.OnVote(pc, voteTarget);
-                                break;
+                            
                             case CustomRoles.Tracker:
                                 Tracker.OnVote(pc, voteTarget);
                                 break;
@@ -769,6 +767,13 @@ class CastVotePatch
                         __instance.RpcClearVote(voter.GetClientId());
                         return false;
                     } //patch here so checkend is not triggered
+                    break;
+                case CustomRoles.Keeper:
+                    if (!Keeper.OnVote(voter, target))
+                    {
+                        __instance.RpcClearVote(voter.GetClientId());
+                        return false;
+                    }
                     break;
             }
         }

--- a/Resources/Lang/en_US.json
+++ b/Resources/Lang/en_US.json
@@ -3003,6 +3003,8 @@
 
   "MaxProtections": "Max protections",
   "KeeperHideVote": "Hide Keeper's vote",
+  "KeeperProtect": "You chose to protect <b>{0}</b>, your vote has been returned",
+  "KeeperTitle": "Keeper",
 
   "MaulKillButtonText": "Maul",
   "MaulRadius": "Maul Radius",

--- a/Roles/Crewmate/Keeper.cs
+++ b/Roles/Crewmate/Keeper.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using UnityEngine;
+using static TOHE.Translator;
 using static TOHE.Options;
 
 namespace TOHE.Roles.Crewmate;
@@ -118,20 +119,22 @@ public static class Keeper
         }
     }
 
-    public static void OnVote(PlayerControl voter, PlayerControl target)
+    public static bool OnVote(PlayerControl voter, PlayerControl target)
     {
-        if (!IsEnable) return;
-        if (voter == null || target == null) return;
-        if (!voter.Is(CustomRoles.Keeper)) return;
-        if (DidVote[voter.PlayerId]) return;
+        if (!IsEnable) return true;
+        if (voter == null || target == null) return true;
+        if (!voter.Is(CustomRoles.Keeper)) return true;
+        if (DidVote[voter.PlayerId]) return true;
         DidVote[voter.PlayerId] = true;
-        if (keeperTarget.Contains(target.PlayerId)) return;
-        if (keeperUses[voter.PlayerId] >= KeeperUsesOpt.GetInt()) return;
+        if (keeperTarget.Contains(target.PlayerId)) return true;
+        if (keeperUses[voter.PlayerId] >= KeeperUsesOpt.GetInt()) return true;
 
         keeperUses[voter.PlayerId]++;
         keeperTarget.Add(target.PlayerId);
         Logger.Info($"{voter.GetNameWithRole()} chosen as keeper target by {target.GetNameWithRole()}", "Keeper");
         SendRPC(type:0, keeperId: voter.PlayerId, targetId: target.PlayerId); // add keeperUses, KeeperTarget and DidVote
+        Utils.SendMessage(string.Format(GetString("KeeperProtect"), target.GetRealName()), voter.PlayerId, title: Utils.ColorString(Utils.GetRoleColor(CustomRoles.Keeper), GetString("KeeperTitle")));
+        return false;
     }
 
     public static void AfterMeetingTasks()

--- a/Roles/Neutral/Pixie.cs
+++ b/Roles/Neutral/Pixie.cs
@@ -58,11 +58,11 @@ public static class Pixie
         MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.SetPixieTargets, SendOption.Reliable, -1);
         writer.Write(pixieId);
         writer.Write(operate);
-        if (!operate)
+        if (!operate) // false = 0
         {
             writer.Write(targetId);
         }
-        else
+        else // true = 1
         {
             writer.Write(PixiePoints[pixieId]);
         }
@@ -117,21 +117,24 @@ public static class Pixie
         if (!IsEnable) return;
         foreach (var pixieId in PixieTargets.Keys.ToArray())
         {
-            var pc = Utils.GetPlayerById(pixieId);
-            if (PixieTargets[pixieId].Count == 0) continue;
-            if (!PixiePoints.ContainsKey(pixieId)) PixiePoints[pixieId] = 0;
-            if (PixiePoints[pixieId] >= PixiePointsToWin.GetInt()) continue;
+            if (exiled != null)
+            { 
+                var pc = Utils.GetPlayerById(pixieId);
+                if (PixieTargets[pixieId].Count == 0) continue;
+                if (!PixiePoints.ContainsKey(pixieId)) PixiePoints[pixieId] = 0;
+                if (PixiePoints[pixieId] >= PixiePointsToWin.GetInt()) continue;
 
-            if (PixieTargets[pixieId].Contains(exiled.PlayerId))
-            {
-                PixiePoints[pixieId]++;
-            }
-            else if (PixieSuicideOpt.GetBool() 
-                && PixieTargets[pixieId].Any(eid => Utils.GetPlayerById(eid)?.IsAlive() == true))
-            {
-                CheckForEndVotingPatch.TryAddAfterMeetingDeathPlayers(PlayerState.DeathReason.Suicide, pixieId);
-                Utils.GetPlayerById(pixieId).SetRealKiller(Utils.GetPlayerById(pixieId));
-                Logger.Info($"{pc.GetNameWithRole()} committed suicide because target not exiled and target(s) were alive during ejection", "Pixie");
+                if (PixieTargets[pixieId].Contains(exiled.PlayerId))
+                {
+                    PixiePoints[pixieId]++;
+                }
+                else if (PixieSuicideOpt.GetBool() 
+                    && PixieTargets[pixieId].Any(eid => Utils.GetPlayerById(eid)?.IsAlive() == true))
+                {
+                    CheckForEndVotingPatch.TryAddAfterMeetingDeathPlayers(PlayerState.DeathReason.Suicide, pixieId);
+                    Utils.GetPlayerById(pixieId).SetRealKiller(Utils.GetPlayerById(pixieId));
+                    Logger.Info($"{pc.GetNameWithRole()} committed suicide because target not exiled and target(s) were alive during ejection", "Pixie");
+                }
             }
             PixieTargets[pixieId].Clear();
             SendRPC(pixieId, true);


### PR DESCRIPTION
1. Returned keeper's vote after selecting target
2. Fix pixie target not being reset when meeting skipped