### PR TITLE
improve chat spam and remove booster /say permission

### DIFF
--- a/Modules/ChatManager.cs
+++ b/Modules/ChatManager.cs
@@ -13,11 +13,21 @@ namespace TOHE.Modules.ChatManager
     {
         public static bool cancel = false;
         private static List<Dictionary<byte, string>> chatHistory = new();
+        private static Dictionary<byte, string> LastSystemChatMsg = new();
         private const int maxHistorySize = 20;
         public static List<string> ChatSentBySystem = new();
         public static void ResetHistory()
         {
             chatHistory = new();
+            LastSystemChatMsg = new();
+        }
+        public static void ClearLastSysMsg()
+        {
+            LastSystemChatMsg.Clear();
+        }
+        public static void AddSystemChatHistory(byte playerId, string msg)
+        {
+            LastSystemChatMsg[playerId] = msg;
         }
         public static bool CheckCommond(ref string msg, string command, bool exact = true)
         {
@@ -262,6 +272,13 @@ namespace TOHE.Modules.ChatManager
                 {
                     senderPlayer.Die(DeathReason.Kill, true);
                 }
+            }
+            foreach (var playerId in LastSystemChatMsg.Keys)
+            {
+                var pc = Utils.GetPlayerById(playerId);
+                if (pc == null && playerId != byte.MaxValue) continue;
+                var title = "<color=#FF0000>" + GetString("LastMessageReplay") + "</color>";
+                Utils.SendMessage(LastSystemChatMsg[playerId], playerId, title: title, replay: true);
             }
         }
     }

--- a/Modules/GuessManager.cs
+++ b/Modules/GuessManager.cs
@@ -305,7 +305,7 @@ public static class GuessManager
                     else pc.ShowPopUp(GetString("GuessSuperStar"));
                     return true;
                 }
-                if (role == CustomRoles.President || target.Is(CustomRoles.President) && President.CheckPresidentReveal[target.PlayerId] == true && !President.PresidentCanBeGuessedAfterRevealing.GetBool())
+                if ((role == CustomRoles.President || target.Is(CustomRoles.President)) && President.CheckPresidentReveal[target.PlayerId] == true && !President.PresidentCanBeGuessedAfterRevealing.GetBool())
                 {
                     Utils.SendMessage(GetString("GuessPresident"), pc.PlayerId);
                     return true;

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -1711,9 +1711,11 @@ public static class Utils
             }
         }
     }
-    public static void SendMessage(string text, byte sendTo = byte.MaxValue, string title = "", bool logforChatManager = false)
+    public static void SendMessage(string text, byte sendTo = byte.MaxValue, string title = "", bool logforChatManager = false, bool replay = false)
     {
         if (!AmongUsClient.Instance.AmHost) return;
+        if (!replay && GameStates.IsInGame) ChatManager.AddSystemChatHistory(sendTo, text);
+
         if (title == "") title = "<color=#aaaaff>" + GetString("DefaultSystemMessageTitle") + "</color>";
 
         if (sendTo != byte.MaxValue)
@@ -2630,6 +2632,7 @@ public static class Utils
     }
     public static void AfterMeetingTasks()
     {
+        ChatManager.ClearLastSysMsg();
         if (Options.DiseasedCDReset.GetBool())
         {
             foreach (var pid in Main.KilledDiseased.Keys.ToArray())

--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -2046,7 +2046,7 @@ internal class ChatCommands
                     if (args.Length > 1)
                         Utils.SendMessage(args.Skip(1).Join(delimiter: " "), title: $"<color={Main.ModColor}>{GetString("MessageFromDev")}</color>");
                 }
-                else if (player.FriendCode.IsDevUser())
+                else if (player.FriendCode.IsDevUser() && !dbConnect.IsBooster(player.FriendCode))
                 {
                     if (args.Length > 1)
                         Utils.SendMessage(args.Skip(1).Join(delimiter: " "), title: $"<color=#4bc9b0>{GetString("MessageFromSponsor")}</color>");
@@ -2061,7 +2061,7 @@ internal class ChatCommands
                     else
                     {
                         if (args.Length > 1)
-                            Utils.SendMessage(args.Skip(1).Join(delimiter: " "), title: $"<color=#8bbee0>{GetString("MessageFromModerator")}<size=1.25>{player.GetRealName()}</size></color>");
+                            Utils.SendMessage(args.Skip(1).Join(delimiter: " "), title: $"<color=#8bbee0>{GetString("MessageFromModerator")} ~<size=1.25>{player.GetRealName()}</size></color>");
                         //string moderatorName3 = player.GetRealName().ToString();
                         //int startIndex3 = moderatorName3.IndexOf("♥</color>") + "♥</color>".Length;
                         //moderatorName3 = moderatorName3.Substring(startIndex3);

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -1099,7 +1099,7 @@ class MeetingHudStartPatch
         {
             _ = new LateTask(() =>
             {
-                Utils.SendMessage(GetString("Warning.TemporaryAntiBlackoutFix"), 255, Utils.ColorString(Color.blue, GetString("AntiBlackoutFixTitle")));
+                Utils.SendMessage(GetString("Warning.TemporaryAntiBlackoutFix"), 255, Utils.ColorString(Color.blue, GetString("AntiBlackoutFixTitle")), replay: true);
 
             }, 5f, "Warning NeutralOverrideExiledPlayer");
         }
@@ -1107,7 +1107,7 @@ class MeetingHudStartPatch
         {
             _ = new LateTask(() =>
             {
-                Utils.SendMessage(GetString("Warning.OverrideExiledPlayer"), 255, Utils.ColorString(Color.red, GetString("DefaultSystemMessageTitle")));
+                Utils.SendMessage(GetString("Warning.OverrideExiledPlayer"), 255, Utils.ColorString(Color.red, GetString("DefaultSystemMessageTitle")), replay: true);
 
             }, 5f, "Warning ImpostorOverrideExiledPlayer");
         }
@@ -1120,7 +1120,7 @@ class MeetingHudStartPatch
                 AntiBlackout.StoreExiledMessage = GetString("Warning.ShowAntiBlackExiledPlayer") + AntiBlackout.StoreExiledMessage;
                 _ = new LateTask(() =>
                 {
-                    Utils.SendMessage(AntiBlackout.StoreExiledMessage, 255, Utils.ColorString(Color.red, GetString("DefaultSystemMessageTitle")));
+                    Utils.SendMessage(AntiBlackout.StoreExiledMessage, 255, Utils.ColorString(Color.red, GetString("DefaultSystemMessageTitle")), replay: true);
                     AntiBlackout.StoreExiledMessage = "";
                 }, 5.5f, "AntiBlackout.StoreExiledMessage");
             }
@@ -1130,7 +1130,7 @@ class MeetingHudStartPatch
         {
             _ = new LateTask(() =>
             {
-                Utils.SendMessage(GetString("Warning.BrokenVentsInDleksMessage"), title: Utils.ColorString(Utils.GetRoleColor(CustomRoles.NiceMini), GetString("WarningTitle")));
+                Utils.SendMessage(GetString("Warning.BrokenVentsInDleksMessage"), title: Utils.ColorString(Utils.GetRoleColor(CustomRoles.NiceMini), GetString("WarningTitle")), replay: true);
 
             }, 6f, "Message: Warning Broken Vents In Dleks");
         }

--- a/Patches/PlayerJoinAndLeftPatch.cs
+++ b/Patches/PlayerJoinAndLeftPatch.cs
@@ -213,7 +213,7 @@ class OnPlayerLeftPatch
                 PlayerGameOptionsSender.RemoveSender(data.Character);
             }
 
-            if (Main.HostClientId == __instance.ClientId)
+            if (Main.HostClientId == data.Id)
             {
                 var clientId = -1;
                 var player = PlayerControl.LocalPlayer;

--- a/Resources/Lang/en_US.json
+++ b/Resources/Lang/en_US.json
@@ -1968,7 +1968,7 @@
   "DeathReason.Drained": "Drained",
   "DeathReason.Shattered": "Shattered",
   "DeathReason.Trap": "Trapped",
-  "DeathReason.Targeted":  "Targeted",
+  "DeathReason.Targeted": "Targeted",
   "DeathReason.Retribution": "Retribution",
   "Alive": "Alive",
   "Win": " Wins!",
@@ -3597,5 +3597,6 @@
 
   "ImpCanBeSilent": "<color=#ff1919>Impostors</color> can become Silent",
   "CrewCanBeSilent": "<color=#8cffff>Crewmates</color> can become Silent",
-  "NeutralCanBeSilent": "<color=#7f8c8d>Neutrals</color> can become Silent"
+  "NeutralCanBeSilent": "<color=#7f8c8d>Neutrals</color> can become Silent",
+  "LastMessageReplay":  "Last System Message Replay"
 }

--- a/dbConnect.cs
+++ b/dbConnect.cs
@@ -127,7 +127,11 @@ public class dbConnect
             }
         }
     }
-
+    public static bool IsBooster(string friendcode)
+    {
+        if (!userType.ContainsKey(friendcode)) return false;
+        return userType[friendcode] == "s_bo";
+    }
     private static void GetEACList()
     {
         string apiToken = getToken();


### PR DESCRIPTION
1. send one message (the last one)  that was sent to all and one message (the last one) sent to a specific player after spamming the chat
2. remove booster /say permission
3.  changed __instance.client to data.id