### PR TITLE
fix counillor per meeting limit and fix null error

### DIFF
--- a/Modules/AntiBlackout.cs
+++ b/Modules/AntiBlackout.cs
@@ -217,10 +217,10 @@ public static class AntiBlackout
     }
     public static void AfterMeetingTasks()
     {
-        if (BlackOutIsActive)
+        if (BlackOutIsActive && CheckForEndVotingPatch.TempExileMsg != null)
         {
             var timeNotify = 4f;
-            foreach (var pc in Main.AllPlayerControls.Where(p => !(p.AmOwner || p.IsModClient())).ToArray())
+            foreach (var pc in Main.AllPlayerControls.Where(p => p != null && !(p.AmOwner || p.IsModClient())).ToArray())
             {
                 pc.Notify(CheckForEndVotingPatch.TempExileMsg, time: timeNotify);
             }

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -2738,6 +2738,7 @@ public static class Utils
         if (Chronomancer.IsEnable) Chronomancer.AfterMeetingTask();
         if (Solsticer.IsEnable) Solsticer.AfterMeetingTasks();
         if (RiftMaker.IsEnable) RiftMaker.AfterMeetingTasks();
+        if (Councillor.IsEnable) Councillor.AfterMeetingTasks();
 
         Main.ShamanTarget = byte.MaxValue;
         Main.ShamanTargetChoosen = false;

--- a/Resources/Lang/en_US.json
+++ b/Resources/Lang/en_US.json
@@ -3106,7 +3106,7 @@
   "GanFarseerCanBeMadmate": "<color=#BA55D3>Overseer</color> can be converted",
   "RascalAppearAsMadmate": "Appear As <color=#ff1919>Madmate</color> On Ejection",
   "CouncillorDead": "Sorry, you can't murder from the dead.",
-  "CouncillorMurderMax": "Sorry, you've reached the maximum amount of murders.",
+  "CouncillorMurderMax": "Sorry, you've reached the maximum amount of murders for the meeting.",
   "LaughToWhoMurderSelf": "Hahaha, who would've thought someone was stupid enough to murder themselves?\n\nGuess it happens to be... YOU!",
   "MurderKill": "<b>{0}</b> was judged.",
   "MurderHelp": "Command: /tl [player ID]\nYou can see the players' IDs before the players' names.\nOr use /id to view the list of all player IDs.",

--- a/Roles/Impostor/Councillor.cs
+++ b/Roles/Impostor/Councillor.cs
@@ -52,10 +52,12 @@ public static class Councillor
         MurderLimit.Add(playerId, MurderLimitPerMeeting.GetInt());
         IsEnable = true;
     }
-    public static void OnReportDeadBody()
+    public static void AfterMeetingTasks()
     {
-        MurderLimit.Clear();
-        foreach (var pc in playerIdList.ToArray()) MurderLimit.Add(pc, MurderLimitPerMeeting.GetInt());
+        foreach (byte playerId in MurderLimit.Keys)
+        {
+            MurderLimit[playerId] = MurderLimitPerMeeting.GetInt();
+        }
     }
     public static bool MurderMsg(PlayerControl pc, string msg, bool isUI = false)
     {
@@ -104,6 +106,7 @@ public static class Councillor
             {
                 Logger.Info($"{pc.GetNameWithRole()} 审判了 {target.GetNameWithRole()}", "Councillor");
                 bool CouncillorSuicide = true;
+                if (!MurderLimit.ContainsKey(pc.PlayerId)) MurderLimit[pc.PlayerId] = MurderLimitPerMeeting.GetInt();
                 if (MurderLimit[pc.PlayerId] < 1)
                 {
                     if (!isUI) Utils.SendMessage(GetString("CouncillorMurderMax"), pc.PlayerId);


### PR DESCRIPTION
1. Fix counillor per meeting limit 
2. Fix null error when there is no `CheckForEndVotingPatch.TempExileMsg` after meeting.