### PR TITLE
Some fix for Doppelganger

### DIFF
--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -646,7 +646,7 @@ internal class RPCHandlerPatch
                 break;
             case CustomRPC.SyncAllPlayerNames:
                 Main.AllPlayerNames = [];
-                int num = reader.ReadInt32();
+                int num = reader.ReadPackedInt32();
                 for (int i = 0; i < num; i++)
                     Main.AllPlayerNames.TryAdd(reader.ReadByte(), reader.ReadString());
                 break;
@@ -947,7 +947,7 @@ internal static class RPC
     {
         if (!AmongUsClient.Instance.AmHost) return;
         MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.SyncAllPlayerNames, SendOption.Reliable, -1);
-        writer.Write(Main.AllPlayerNames.Count);
+        writer.WritePacked(Main.AllPlayerNames.Count);
         foreach (var name in Main.AllPlayerNames)
         {
             writer.Write(name.Key);

--- a/Roles/Neutral/Doppelganger.cs
+++ b/Roles/Neutral/Doppelganger.cs
@@ -174,7 +174,8 @@ public static class Doppelganger
         Logger.Info("Changed killer skin", "Doppelganger");
 
         SendRPC(killer.PlayerId);
-        Utils.NotifyRoles(ForceLoop: true);
+        Utils.NotifyRoles(ForceLoop: true, NoCache: true);
+        RPC.SyncAllPlayerNames();
         killer.ResetKillCooldown();
         killer.SetKillCooldown();
         return;

--- a/Roles/Neutral/Doppelganger.cs
+++ b/Roles/Neutral/Doppelganger.cs
@@ -136,7 +136,7 @@ public static class Doppelganger
 
     public static void OnCheckMurder(PlayerControl killer, PlayerControl target)
     {
-        if (killer == null || target == null || !IsEnable || Camouflage.IsCamouflage || Camouflager.AbilityActivated) return;
+        if (killer == null || target == null || !IsEnable || Camouflage.IsCamouflage || Camouflager.AbilityActivated || Utils.IsActive(SystemTypes.MushroomMixupSabotage)) return;
         if (Main.CheckShapeshift.TryGetValue(target.PlayerId, out bool isShapeshifitng) && isShapeshifitng)
         {
             Logger.Info("Target was shapeshifting", "Doppelganger");


### PR DESCRIPTION
1. Fix updating of player names after kill committed by Doppelganger
2. Skin Doppelganger now can't chenged during MushroomMixup sabotage