### PR TITLE
Fix lawyer

### DIFF
--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -2683,6 +2683,7 @@ public static class Utils
         if (Councillor.IsEnable) Councillor.AfterMeetingTasks();
         if (Statue.IsEnable) Statue.AfterMeetingTasks();
         if (Burst.IsEnable) Burst.AfterMeetingTasks();
+        if (Lawyer.IsEnable) Lawyer.AfterMeetingTasks();
 
         Main.ShamanTarget = byte.MaxValue;
         Main.ShamanTargetChoosen = false;

--- a/Patches/ExilePatch.cs
+++ b/Patches/ExilePatch.cs
@@ -157,22 +157,10 @@ class ExileControllerWrapUpPatch
                 Devourer.OnDevourerDied(exiled.PlayerId);
             }
 
-            //Lawyer check win
-            if (Lawyer.CheckExileTarget(exiled, DecidedWinner))
-            {
-                DecidedWinner = false;
-            }
-
             if (role.Is(CustomRoles.Devourer))
             {
                 Devourer.OnDevourerDied(exiled.PlayerId);
             }
-
-            if (Lawyer.CheckExileTarget(exiled, DecidedWinner))
-            {
-                DecidedWinner = false;
-            }
-
 
             if (CustomWinnerHolder.WinnerTeam != CustomWinner.Terrorist) Main.PlayerStates[exiled.PlayerId].SetDead();
 

--- a/Patches/PlayerJoinAndLeftPatch.cs
+++ b/Patches/PlayerJoinAndLeftPatch.cs
@@ -284,10 +284,10 @@ class OnPlayerLeftPatch
                     Executioner.ChangeRoleByTarget(data.Character);
                 }
                 
-                if (data.Character.Is(CustomRoles.Lawyer) && Lawyer.Target.ContainsKey(data.Character.PlayerId))
-                {
-                    Lawyer.ChangeRole(data.Character);
-                }
+                //if (data.Character.Is(CustomRoles.Lawyer) && Lawyer.Target.ContainsKey(data.Character.PlayerId))
+                //{
+                //    Lawyer.ChangeRole(data.Character);
+                //}
                 if (Lawyer.Target.ContainsValue(data.Character.PlayerId))
                 {
                     Lawyer.ChangeRoleByTarget(data.Character);

--- a/Resources/Lang/en_US.json
+++ b/Resources/Lang/en_US.json
@@ -1540,7 +1540,10 @@
   "LawyerCanTargetNeutralKiller": "Can Target <color=#7f8c8d>Neutral Killers</color>",
   "LawyerCanTargetCrewmate": "Can Target <color=#8cffff>Crewmates</color>",
   "LawyerCanTargetJester": "Can Target <color=#ec62a5>Jester</color>",
+  "LaywerShouldChangeRoleAfterTargetKilled": "Should Laywer Change Role when Target Dies",
   "LawyerChangeRolesAfterTargetKilled": "When Target Dies, <color=#008080>Lawyer</color> becomes",
+
+  "LawyerTargetDeadInMeeting": "Your target was killed while meeting./nYour role may change depending on the settings.",
   "MercenaryLimit": "Time Until Suicide",
   "ArsonistDouseTime": "Douse Duration",
   "CanTerroristSuicideWin": "Can Win By Suicide",


### PR DESCRIPTION
If lawyer has no available target, will try to assign other roles for it.
Add a setting where laywer should change role after target dies.