### PR TITLE
Increase character limit for sending chat messages

### DIFF
--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -2425,7 +2425,9 @@ class ChatUpdatePatch
         
         int clientId = sendTo == byte.MaxValue ? -1 : Utils.GetPlayerById(sendTo).GetClientId();
         var name = player.Data.PlayerName;
-        
+
+        __instance.freeChatField.textArea.characterLimit = 999;
+
         if (clientId == -1)
         {
             player.SetName(title);


### PR DESCRIPTION
There is a possibility that the message may be too large to send and he cannot send it to the player