### PR TITLE
Start ReceiveRPC Override + Improvements

### DIFF
--- a/Modules/Camouflague.cs
+++ b/Modules/Camouflague.cs
@@ -136,7 +136,7 @@ public static class Camouflage
     }
     public static void CheckCamouflage()
     {
-        if (!(AmongUsClient.Instance.AmHost && (Options.CommsCamouflage.GetBool() || Camouflager.On))) return;
+        if (!(AmongUsClient.Instance.AmHost && (Options.CommsCamouflage.GetBool() || Camouflager.HasEnabled))) return;
 
         var oldIsCamouflage = IsCamouflage;
 
@@ -158,7 +158,7 @@ public static class Camouflage
     }
     public static void RpcSetSkin(PlayerControl target, bool ForceRevert = false, bool RevertToDefault = false, bool GameEnd = false)
     {
-        if (!(AmongUsClient.Instance.AmHost && (Options.CommsCamouflage.GetBool() || Camouflager.On))) return;
+        if (!(AmongUsClient.Instance.AmHost && (Options.CommsCamouflage.GetBool() || Camouflager.HasEnabled))) return;
         if (target == null) return;
 
         var id = target.PlayerId;

--- a/Modules/CustomRolesHelper.cs
+++ b/Modules/CustomRolesHelper.cs
@@ -1535,20 +1535,40 @@ public static class CustomRolesHelper
             _ => role.IsImpostor() ? RoleTypes.Impostor : RoleTypes.Crewmate,
         };
     public static bool IsDesyncRole(this CustomRoles role) => role.GetDYRole() != RoleTypes.GuardianAngel;
+    /// <summary>
+    /// Role is Madmate Or Impostor
+    /// </summary>
     public static bool IsImpostorTeam(this CustomRoles role) => role.IsImpostor() || role == CustomRoles.Madmate;
+    /// <summary>
+    /// Role Is Not Impostor nor Madmate Nor Neutral.
+    /// </summary>
     public static bool IsCrewmate(this CustomRoles role) => !role.IsImpostor() && !role.IsNeutral() && !role.IsMadmate();
-
-    public static bool IsImpostorTeamV2(this CustomRoles role) => role == CustomRoles.Rascal || role == CustomRoles.Madmate || (role.IsImpostorTeamV3() && role != CustomRoles.Trickster && !role.IsConverted());
-    public static bool IsNeutralTeamV2(this CustomRoles role) => (role.IsConverted() || role.IsNeutral()) && role != CustomRoles.Madmate;
+    /// <summary>
+    /// Role is Rascal or Madmate and not trickster.
+    /// </summary>
+    public static bool IsImpostorTeamV2(this CustomRoles role) => role == CustomRoles.Rascal || role == CustomRoles.Madmate || (role.IsImpostorTeamV3() && role != CustomRoles.Trickster && (!role.IsConverted() || role is CustomRoles.Madmate));
+    /// <summary>
+    /// Role Is Converting or neutral.
+    /// </summary>
+    public static bool IsNeutralTeamV2(this CustomRoles role) => (role.IsConverted() && role != CustomRoles.Madmate || role.IsNeutral()) && role != CustomRoles.Madmate;
+    /// <summary>
+    /// Role is not impostor nor rascal nor madmate nor converting nor neutral or role is trickster.
+    /// </summary>
     public static bool IsCrewmateTeamV2(this CustomRoles role) => !(role.IsImpostorTeamV2() || role.IsNeutralTeamV2()) || role == CustomRoles.Trickster;
 
+    /// <summary>
+    /// Role Changes the Crewmates Team, Including changing to Impostor.
+    /// </summary>
     public static bool IsConverted(this CustomRoles role)
     {
-        return (role is CustomRoles.Charmed ||
-                role is CustomRoles.Recruit ||
-                role is CustomRoles.Infected ||
-                role is CustomRoles.Contagious ||
-                role is CustomRoles.Lovers ||
+        return (role is CustomRoles.Charmed 
+                or CustomRoles.Recruit
+                or CustomRoles.Infected
+                or CustomRoles.Contagious
+                or CustomRoles.Soulless
+                or CustomRoles.Lovers 
+                or CustomRoles.Rogue
+                or CustomRoles.Madmate ||
                 (role is CustomRoles.Egoist && Egoist.EgoistCountAsConverted.GetBool()));
     }
     public static bool IsEvilAddons(this CustomRoles role)

--- a/Modules/CustomRolesHelper.cs
+++ b/Modules/CustomRolesHelper.cs
@@ -7,7 +7,6 @@ using TOHE.Roles.Crewmate;
 using TOHE.Roles.Impostor;
 using TOHE.Roles.Neutral;
 using TOHE.Roles.AddOns.Impostor;
-using Rewired;
 
 namespace TOHE;
 

--- a/Modules/CustomRolesHelper.cs
+++ b/Modules/CustomRolesHelper.cs
@@ -7,6 +7,7 @@ using TOHE.Roles.Crewmate;
 using TOHE.Roles.Impostor;
 using TOHE.Roles.Neutral;
 using TOHE.Roles.AddOns.Impostor;
+using Rewired;
 
 namespace TOHE;
 
@@ -18,15 +19,18 @@ public static class CustomRolesHelper
     {
         // Vanilla roles
         if (role.IsVanilla()) return role;
-        if (role == CustomRoles.ShapeshifterTOHE) return CustomRoles.Shapeshifter;
-        if (role == CustomRoles.ScientistTOHE) return CustomRoles.Scientist;
-        if (role == CustomRoles.EngineerTOHE) return CustomRoles.Engineer;
 
         // Role base
         if (role.IsRoleClass() is not VanillaRole) return role.IsRoleClass().ThisRoleBase;
 
-        // Default
-        return role.IsImpostor() ? CustomRoles.Impostor : CustomRoles.Crewmate; 
+        //Default
+        return role switch
+        {
+            CustomRoles.ShapeshifterTOHE => CustomRoles.Shapeshifter,
+            CustomRoles.ScientistTOHE => CustomRoles.Scientist,
+            CustomRoles.EngineerTOHE => CustomRoles.Engineer,
+            _ => role.IsImpostor() ? CustomRoles.Impostor : CustomRoles.Crewmate,
+        };
     }
     
     public static RoleTypes GetDYRole(this CustomRoles role) // Role has a kill button (Non-Impostor)

--- a/Modules/CustomRolesHelper.cs
+++ b/Modules/CustomRolesHelper.cs
@@ -25,7 +25,7 @@ public static class CustomRolesHelper
         // Role base
         if (role.IsRoleClass() is not VanillaRole) return role.IsRoleClass().ThisRoleBase;
 
-        // Defult
+        // Default
         return role.IsImpostor() ? CustomRoles.Impostor : CustomRoles.Crewmate; 
     }
     

--- a/Modules/CustomRpcSender.cs
+++ b/Modules/CustomRpcSender.cs
@@ -237,7 +237,7 @@ public static class CustomRpcSenderExtensions
             .Write((ushort)role)
             .EndRpc();
     }
-    public static void RpcMurderPlayer(this CustomRpcSender sender, PlayerControl player, PlayerControl target, int targetClientId = -1)
+    public static void RpcMurderPlayerV3(this CustomRpcSender sender, PlayerControl player, PlayerControl target, int targetClientId = -1)
     {
         sender.AutoStartRpc(player.NetId, (byte)RpcCalls.MurderPlayer, targetClientId)
             .WriteNetObject(target)

--- a/Modules/CustomRpcSender.cs
+++ b/Modules/CustomRpcSender.cs
@@ -237,7 +237,7 @@ public static class CustomRpcSenderExtensions
             .Write((ushort)role)
             .EndRpc();
     }
-    public static void RpcMurderPlayerV3(this CustomRpcSender sender, PlayerControl player, PlayerControl target, int targetClientId = -1)
+    public static void RpcMurderPlayer(this CustomRpcSender sender, PlayerControl player, PlayerControl target, int targetClientId = -1)
     {
         sender.AutoStartRpc(player.NetId, (byte)RpcCalls.MurderPlayer, targetClientId)
             .WriteNetObject(target)

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -640,17 +640,6 @@ static class ExtendedPlayerControl
     }
     public static void RpcMurderPlayerV3(this PlayerControl killer, PlayerControl target)
     {
-        if (target.Is(CustomRoles.Pestilence) && killer != target) { killer.SetRealKiller(target); (killer, target) = (target, killer); Main.PlayerStates[target.PlayerId].deathReason = PlayerState.DeathReason.PissedOff; goto postPest; }
-        else if (target.Is(CustomRoles.Pestilence) && target.GetRealKiller() != null && target.GetRealKiller() != target) { var truekill = target.GetRealKiller(); (killer, target) = (target, truekill); Main.PlayerStates[target.PlayerId].deathReason = PlayerState.DeathReason.PissedOff; goto postPest; }
-        else if(target.Is(CustomRoles.Pestilence)) { return; }
-        postPest:
-
-        if (Solsticer.OnCheckRpcMurderv3(killer, target))
-            return;
-
-        if (target.Is(CustomRoles.Susceptible))
-            Susceptible.CallEnabledAndChange(target);
-
         if (killer.PlayerId == target.PlayerId && killer.shapeshifting)
         {
             _ = new LateTask(() => { killer.RpcMurderPlayer(target, true); }, 1.5f, "Shapeshifting Suicide Delay");
@@ -658,19 +647,6 @@ static class ExtendedPlayerControl
         }
 
         killer.RpcMurderPlayer(target, true);
-    }
-    public static void RpcMurderPlayerV2(this PlayerControl killer, PlayerControl target)
-    {
-        if (target == null) target = killer;
-        if (AmongUsClient.Instance.AmClient)
-        {
-            killer.MurderPlayer(target, ResultFlags);
-        }
-        MessageWriter messageWriter = AmongUsClient.Instance.StartRpcImmediately(killer.NetId, (byte)RpcCalls.MurderPlayer, SendOption.None, -1);
-        messageWriter.WriteNetObject(target);
-        messageWriter.Write((int)ResultFlags);
-        AmongUsClient.Instance.FinishRpcImmediately(messageWriter);
-        Utils.NotifyRoles();
     }
     public static void RpcMurderPlayer(this PlayerControl killer, PlayerControl target)
     {

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -803,15 +803,14 @@ static class ExtendedPlayerControl
         else if (Main.VisibleTasksCount && !seer.IsAlive() && Options.GhostCanSeeOtherRoles.GetBool()) return true;
         else if (Options.ImpsCanSeeEachOthersAddOns.GetBool() && seer.Is(CustomRoleTypes.Impostor) && target.Is(CustomRoleTypes.Impostor) && !subRole.IsEvilAddons()) return true;
 
-        else if (
-            (subRole.Is(CustomRoles.Madmate)
-                || subRole.Is(CustomRoles.Sidekick) 
-                || subRole.Is(CustomRoles.Recruit)
-                || subRole.Is(CustomRoles.Admired)
-                || subRole.Is(CustomRoles.Charmed)
-                || subRole.Is(CustomRoles.Infected)
-                || subRole.Is(CustomRoles.Contagious)
-                || subRole.Is(CustomRoles.Egoist)) 
+        else if ((subRole is CustomRoles.Madmate
+                or CustomRoles.Sidekick
+                or CustomRoles.Recruit
+                or CustomRoles.Admired
+                or CustomRoles.Charmed
+                or CustomRoles.Infected
+                or CustomRoles.Contagious
+                or CustomRoles.Egoist) 
             && KnowSubRoleTarget(seer, target))
             return true;
 
@@ -1005,7 +1004,6 @@ static class ExtendedPlayerControl
     public static bool Is(this PlayerControl target, CustomRoleTypes type) { return target.GetCustomRole().GetCustomRoleTypes() == type; }
     public static bool Is(this PlayerControl target, RoleTypes type) { return target.GetCustomRole().GetRoleTypes() == type; }
     public static bool Is(this PlayerControl target, CountTypes type) { return target.GetCountTypes() == type; }
-    public static bool Is(this CustomRoles trueRole, CustomRoles checkRole) { return trueRole == checkRole; }
     public static bool IsAnySubRole(this PlayerControl target, Func<CustomRoles, bool> predicate) => target.GetCustomSubRoles().Count > 0 && target.GetCustomSubRoles().Any(predicate);
 
     public static bool IsAlive(this PlayerControl target)

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -638,16 +638,6 @@ static class ExtendedPlayerControl
         MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(player.NetId, (byte)RpcCalls.Exiled, SendOption.None, -1);
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void RpcMurderPlayerV3(this PlayerControl killer, PlayerControl target)
-    {
-        if (killer.PlayerId == target.PlayerId && killer.shapeshifting) 
-        {
-            _ = new LateTask(() => { killer.RpcMurderPlayer(target, true); }, 1.5f, "Shapeshifting Suicide Delay");
-            return;
-        }
-
-        killer.RpcMurderPlayer(target, true);
-    }
     public static void RpcMurderPlayer(this PlayerControl killer, PlayerControl target)
     {
         var RealKiller = target.GetRealKiller() ? target.GetRealKiller() : killer;

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -638,6 +638,9 @@ static class ExtendedPlayerControl
         MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(player.NetId, (byte)RpcCalls.Exiled, SendOption.None, -1);
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
+    /// <summary>
+    /// ONLY to be used when killer surely may kill the target, please check with killer.RpcCheckAndMurder(target, check: true) for indirect kill.
+    /// </summary>
     public static void RpcMurderPlayer(this PlayerControl killer, PlayerControl target)
     {
         var RealKiller = target.GetRealKiller() ? target.GetRealKiller() : killer;

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -674,6 +674,8 @@ static class ExtendedPlayerControl
     }
     public static void RpcMurderPlayer(this PlayerControl killer, PlayerControl target)
     {
+        var RealKiller = target.GetRealKiller() ? target.GetRealKiller() : killer;
+        target.SetRealKiller(RealKiller);
         killer.RpcMurderPlayer(target, true);
     }
 

--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -640,7 +640,7 @@ static class ExtendedPlayerControl
     }
     public static void RpcMurderPlayerV3(this PlayerControl killer, PlayerControl target)
     {
-        if (killer.PlayerId == target.PlayerId && killer.shapeshifting)
+        if (killer.PlayerId == target.PlayerId && killer.shapeshifting) 
         {
             _ = new LateTask(() => { killer.RpcMurderPlayer(target, true); }, 1.5f, "Shapeshifting Suicide Delay");
             return;

--- a/Modules/GameOptionsSender/PlayerGameOptionsSender.cs
+++ b/Modules/GameOptionsSender/PlayerGameOptionsSender.cs
@@ -104,96 +104,20 @@ public class PlayerGameOptionsSender(PlayerControl player) : GameOptionsSender
                 opt.SetFloat(FloatOptionNames.ImpostorLightMod, 1.25f);
             }
         }
-        
+
+        if (player.GetCustomRole().GetCustomRoleTypes() is CustomRoleTypes.Impostor)
+        {
+            AURoleOptions.ShapeshifterCooldown = Options.DefaultShapeshiftCooldown.GetFloat();
+            opt.SetVision(true);
+        }
+
         if (role.IsGhostRole())
             AURoleOptions.GuardianAngelCooldown = Options.DefaultAngelCooldown.GetFloat();
-        else if (!role.IsGhostRole() || player.IsAnySubRole(x => x is CustomRoles.EvilSpirit)) 
-        {
-            switch (role.GetCustomRoleTypes())
-            {
-                case CustomRoleTypes.Impostor:
-                    AURoleOptions.ShapeshifterCooldown = Options.DefaultShapeshiftCooldown.GetFloat();
-                    AURoleOptions.GuardianAngelCooldown = Spiritcaller.SpiritAbilityCooldown.GetFloat();
-                    opt.SetVision(true);
-                    break;
-                case CustomRoleTypes.Neutral:
-                    AURoleOptions.GuardianAngelCooldown = Spiritcaller.SpiritAbilityCooldown.GetFloat();
-                    break;
-                case CustomRoleTypes.Crewmate:
-                    AURoleOptions.GuardianAngelCooldown = Spiritcaller.SpiritAbilityCooldown.GetFloat();
-                    break;
-            }
-        }
 
-        player.GetRoleClass()?.ApplyGameOptions(opt, player.PlayerId);
-
-        switch (role)
-        {
-            case CustomRoles.ShapeshifterTOHE:
-                AURoleOptions.ShapeshifterCooldown = Options.ShapeshiftCD.GetFloat();
-                AURoleOptions.ShapeshifterDuration = Options.ShapeshiftDur.GetFloat();
-                break;
-            case CustomRoles.ScientistTOHE:
-                AURoleOptions.ScientistCooldown = Options.ScientistCD.GetFloat();
-                AURoleOptions.ScientistBatteryCharge = Options.ScientistDur.GetFloat();
-                break;
-            case CustomRoles.EngineerTOHE:
-                AURoleOptions.EngineerCooldown = 0f;
-                AURoleOptions.EngineerInVentMaxTime = 0f;
-                break;
-            default:
-                opt.SetVision(false);
-                break;
-        }
-
-        if (Grenadier.HasEnabled) Grenadier.ApplyGameOptionsForOthers(opt, player);
-        if (Dazzler.On) Dazzler.SetDazzled(player, opt);
-        if (Deathpact.On) Deathpact.SetDeathpactVision(player, opt);
-        if (Spiritcaller.HasEnabled) Spiritcaller.ReduceVision(opt, player);
-        if (Pitfall.On) Pitfall.SetPitfallTrapVision(opt, player);
-
-        // Add-ons
-        if (Bewilder.IsEnable) Bewilder.ApplyGameOptions(opt, player);
-        if (Ghoul.IsEnable) Ghoul.ApplyGameOptions(player);
-
-        var playerSubRoles = player.GetCustomSubRoles();
-
-        if (playerSubRoles.Any())
-            foreach (var subRole in playerSubRoles.ToArray())
-            {
-                switch (subRole)
-                {
-                    case CustomRoles.Watcher:
-                        Watcher.RevealVotes(opt);
-                        break;
-                    case CustomRoles.Flash:
-                        Flash.SetSpeed(player.PlayerId, false);
-                        break;
-                    case CustomRoles.Torch:
-                        Torch.ApplyGameOptions(opt);
-                        break;
-                    case CustomRoles.Tired:
-                        Tired.ApplyGameOptions(opt, player);
-                        break;
-                    case CustomRoles.Bewilder:
-                        Bewilder.ApplyVisionOptions(opt);
-                        break;
-                    case CustomRoles.Reach:
-                        Reach.ApplyGameOptions(opt);
-                        break;
-                    case CustomRoles.Madmate:
-                        Madmate.ApplyGameOptions(opt);
-                        break;
-                    case CustomRoles.Mare:
-                        Mare.ApplyGameOptions(player.PlayerId);
-                        break;
-                    //case CustomRoles.Sunglasses:
-                        //opt.SetVision(false);
-                        //opt.SetFloat(FloatOptionNames.CrewLightMod, Options.SunglassesVision.GetFloat());
-                        //opt.SetFloat(FloatOptionNames.ImpostorLightMod, Options.SunglassesVision.GetFloat());
-                        //break;
-                }
-            }
+        /*
+         * Builds Modified GameOptions
+         */
+        player.BuildCustomGameOptions(ref opt, role);
 
         AURoleOptions.EngineerCooldown = Mathf.Max(0.01f, AURoleOptions.EngineerCooldown);
 

--- a/Modules/GameState.cs
+++ b/Modules/GameState.cs
@@ -159,7 +159,7 @@ public class PlayerState(byte playerId)
             SubRoles.Add(role);
         if (role.IsConverted())
         {
-            SubRoles.Where(AddON => AddON != role).Do(x => SubRoles.Remove(x));
+            SubRoles.Where(AddON => AddON != role && AddON.IsConverted()).Do(x => SubRoles.Remove(x));
             SubRoles.Remove(CustomRoles.Rogue);
             SubRoles.Remove(CustomRoles.Rascal);
             SubRoles.Remove(CustomRoles.Loyal);

--- a/Modules/GameState.cs
+++ b/Modules/GameState.cs
@@ -10,6 +10,7 @@ using TOHE.Roles.Neutral;
 using UnityEngine;
 using static TOHE.Utils;
 using TOHE.Roles.Impostor;
+using HarmonyLib;
 
 namespace TOHE;
 
@@ -156,6 +157,14 @@ public class PlayerState(byte playerId)
 
         if (!SubRoles.Contains(role))
             SubRoles.Add(role);
+        if (role.IsConverted())
+        {
+            SubRoles.Where(AddON => AddON != role).Do(x => SubRoles.Remove(x));
+            SubRoles.Remove(CustomRoles.Rogue);
+            SubRoles.Remove(CustomRoles.Rascal);
+            SubRoles.Remove(CustomRoles.Loyal);
+            SubRoles.Remove(CustomRoles.Admired);
+        }
 
         switch (role)
         {
@@ -171,15 +180,6 @@ public class PlayerState(byte playerId)
                     2 => countTypes,
                     _ => throw new NotImplementedException()
                 };
-                SubRoles.Remove(CustomRoles.Charmed);
-                SubRoles.Remove(CustomRoles.Recruit);
-                SubRoles.Remove(CustomRoles.Infected);
-                SubRoles.Remove(CustomRoles.Contagious);
-                SubRoles.Remove(CustomRoles.Rogue);
-                SubRoles.Remove(CustomRoles.Rascal);
-                SubRoles.Remove(CustomRoles.Soulless);
-                SubRoles.Remove(CustomRoles.Loyal);
-                SubRoles.Remove(CustomRoles.Admired);
                 break;
 
             case CustomRoles.Charmed:
@@ -190,15 +190,6 @@ public class PlayerState(byte playerId)
                     2 => countTypes,
                     _ => throw new NotImplementedException()
                 };
-                SubRoles.Remove(CustomRoles.Madmate);
-                SubRoles.Remove(CustomRoles.Recruit);
-                SubRoles.Remove(CustomRoles.Infected);
-                SubRoles.Remove(CustomRoles.Contagious);
-                SubRoles.Remove(CustomRoles.Rogue);
-                SubRoles.Remove(CustomRoles.Rascal);
-                SubRoles.Remove(CustomRoles.Soulless);
-                SubRoles.Remove(CustomRoles.Loyal);
-                SubRoles.Remove(CustomRoles.Admired);
                 break;
 
             case CustomRoles.Recruit:
@@ -209,29 +200,10 @@ public class PlayerState(byte playerId)
                     2 => countTypes,
                     _ => throw new NotImplementedException()
                 };
-                SubRoles.Remove(CustomRoles.Madmate);
-                SubRoles.Remove(CustomRoles.Charmed);
-                SubRoles.Remove(CustomRoles.Infected);
-                SubRoles.Remove(CustomRoles.Contagious);
-                SubRoles.Remove(CustomRoles.Rogue);
-                SubRoles.Remove(CustomRoles.Rascal);
-                SubRoles.Remove(CustomRoles.Soulless);
-                SubRoles.Remove(CustomRoles.Loyal);
-                SubRoles.Remove(CustomRoles.Loyal);
-                SubRoles.Remove(CustomRoles.Admired);
                 break;
 
             case CustomRoles.Infected:
                 countTypes = CountTypes.Infectious;
-                SubRoles.Remove(CustomRoles.Madmate);
-                SubRoles.Remove(CustomRoles.Recruit);
-                SubRoles.Remove(CustomRoles.Charmed);
-                SubRoles.Remove(CustomRoles.Rogue);
-                SubRoles.Remove(CustomRoles.Contagious);
-                SubRoles.Remove(CustomRoles.Rascal);
-                SubRoles.Remove(CustomRoles.Soulless);
-                SubRoles.Remove(CustomRoles.Loyal);
-                SubRoles.Remove(CustomRoles.Admired);
                 break;
 
             case CustomRoles.Contagious:
@@ -242,28 +214,10 @@ public class PlayerState(byte playerId)
                     2 => countTypes,
                     _ => throw new NotImplementedException()
                 };
-                SubRoles.Remove(CustomRoles.Madmate);
-                SubRoles.Remove(CustomRoles.Recruit);
-                SubRoles.Remove(CustomRoles.Rogue);
-                SubRoles.Remove(CustomRoles.Charmed);
-                SubRoles.Remove(CustomRoles.Infected);
-                SubRoles.Remove(CustomRoles.Rascal);
-                SubRoles.Remove(CustomRoles.Soulless);
-                SubRoles.Remove(CustomRoles.Loyal);
-                SubRoles.Remove(CustomRoles.Admired);
                 break;
 
             case CustomRoles.Rogue:
                 countTypes = CountTypes.Rogue;
-                SubRoles.Remove(CustomRoles.Madmate);
-                SubRoles.Remove(CustomRoles.Recruit);
-                SubRoles.Remove(CustomRoles.Charmed);
-                SubRoles.Remove(CustomRoles.Infected);
-                SubRoles.Remove(CustomRoles.Contagious);
-                SubRoles.Remove(CustomRoles.Rascal);
-                SubRoles.Remove(CustomRoles.Soulless);
-                SubRoles.Remove(CustomRoles.Loyal);
-                SubRoles.Remove(CustomRoles.Admired);
                 break;
 
             // This exist as it would be possible for them to exist on the same player via Bandit
@@ -274,28 +228,10 @@ public class PlayerState(byte playerId)
 
             case CustomRoles.Admired:
                 countTypes = CountTypes.Crew;
-                SubRoles.Remove(CustomRoles.Madmate);
-                SubRoles.Remove(CustomRoles.Recruit);
-                SubRoles.Remove(CustomRoles.Charmed);
-                SubRoles.Remove(CustomRoles.Infected);
-                SubRoles.Remove(CustomRoles.Contagious);
-                SubRoles.Remove(CustomRoles.Rascal);
-                SubRoles.Remove(CustomRoles.Soulless);
-                SubRoles.Remove(CustomRoles.Loyal);
-                SubRoles.Remove(CustomRoles.Rogue);
                 break;
 
             case CustomRoles.Soulless:
                 countTypes = CountTypes.OutOfGame;
-                SubRoles.Remove(CustomRoles.Madmate);
-                SubRoles.Remove(CustomRoles.Recruit);
-                SubRoles.Remove(CustomRoles.Charmed);
-                SubRoles.Remove(CustomRoles.Infected);
-                SubRoles.Remove(CustomRoles.Contagious);
-                SubRoles.Remove(CustomRoles.Rascal);
-                SubRoles.Remove(CustomRoles.Rogue);
-                SubRoles.Remove(CustomRoles.Loyal);
-                SubRoles.Remove(CustomRoles.Admired);
                 break;
         }
     }

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -329,7 +329,7 @@ internal class RPCHandlerPatch
                 RPC.SetCustomRole(CustomRoleTargetId, role);
                 break;
             case CustomRPC.SyncRoleSkill:
-                RPC.SyncRoleSkillReader(reader);
+                RPC.SyncRoleSkillReader(reader, __instance);
                 break;
             case CustomRPC.SetBountyTarget:
                 BountyHunter.ReceiveRPC(reader);
@@ -517,7 +517,7 @@ internal class RPCHandlerPatch
                 Retributionist.ReceiveRPC(reader, __instance);
                 break;
             case CustomRPC.SetChameleonTimer:
-                Chameleon.ReceiveRPC(reader);
+                Main.RoleClass[CustomRoles.Chameleon].ReceiveRPC(reader, __instance);
                 break;
             case CustomRPC.SetAlchemistTimer:
                 Alchemist.ReceiveRPC(reader);
@@ -852,7 +852,7 @@ internal static class RPC
 
         if (PlayerControl.LocalPlayer.PlayerId == targetId) RemoveDisableDevicesPatch.UpdateDisableDevices();
     }
-    public static void SyncRoleSkillReader(MessageReader reader)
+    public static void SyncRoleSkillReader(MessageReader reader, PlayerControl pc)
     {
         CustomRoles role = (CustomRoles)reader.ReadPackedInt32();
         Logger.Info($"Received Sync Role Skill RPC for role {role}", "SyncRoleSkillReader");
@@ -863,212 +863,8 @@ internal static class RPC
             case CustomRoles.Admirer:
                 Admirer.ReceiveRPC(reader, false);
                 break;
-            case CustomRoles.Coroner:
-                Coroner.ReceiveRPCLimit(reader);
-                break;
-            case CustomRoles.Chameleon:
-                Chameleon.ReceiveRPC(reader);
-                break;
-            case CustomRoles.ChiefOfPolice:
-                ChiefOfPolice.ReceiveRPC(reader);
-                break;
-            case CustomRoles.Cleanser:
-                Cleanser.ReceiveRPC(reader);
-                break;
-            case CustomRoles.Deceiver:
-                Deceiver.ReceiveRPC(reader);
-                break;
-            case CustomRoles.Crusader:
-                Crusader.ReceiveRPC(reader);
-                break;
-            case CustomRoles.Deputy:
-                Deputy.ReceiveRPC(reader);
-                break; 
-                //Waiting for fix
-            case CustomRoles.FortuneTeller:
-                FortuneTeller.ReceiveRPC(reader);
-                break;
-            case CustomRoles.Medic:
-                Medic.ReceiveRPC(reader);
-                break;
-            case CustomRoles.Medium:
-                Medium.ReceiveRPC(reader);
-                break;
-            case CustomRoles.Monarch:
-                Monarch.ReceiveRPC(reader);
-                break;
-            case CustomRoles.Oracle:
-                Oracle.ReceiveRPC(reader);
-                break;
-            case CustomRoles.Mechanic:
-                Mechanic.ReceiveRPC(reader);
-                break;
-            case CustomRoles.Sheriff:
-                Sheriff.ReceiveRPC(reader);
-                break;
-            case CustomRoles.Spy:
-                Spy.ReceiveRPC(reader, isAbility: true);
-                break;
-            case CustomRoles.Swapper:
-                Swapper.ReceiveSkillRPC(reader);
-                break;
-            case CustomRoles.Knight:
-                Knight.ReceiveRPC(reader);
-                break;
-
-            //Impostors
-            case CustomRoles.Anonymous:
-                Anonymous.ReceiveRPC(reader);
-                break;
-            //case CustomRoles.Councillor:
-            //    break;
-            //Wait for bug fix
-            case CustomRoles.Eraser:
-                Eraser.ReceiveRPC(reader);
-                break;
-            case CustomRoles.Gangster:
-                Gangster.ReceiveRPC(reader);
-                break;
-            //case CustomRoles.Instigator:
-            //    break;
-            //Wait for bug fix
-            case CustomRoles.Penguin:
-                Penguin.ReceiveRPC(reader);
-                break;
-            case CustomRoles.QuickShooter:
-                QuickShooter.ReceiveRPC(reader);
-                break;
-            case CustomRoles.Stealth:
-                Stealth.ReceiveRPC(reader);
-                break;
-            case CustomRoles.Swooper:
-                Swooper.ReceiveRPC(reader);
-                break;
-            case CustomRoles.Wildling:
-                Wildling.ReceiveRPC(reader);
-                break;
-            //case CustomRoles.Witch:
-            //    break;
-            //Merge the two rpc into one
-
-            //Double
-            case CustomRoles.Mini:
-                Mini.ReceiveRPC(reader);
-                break;
-            // Nice mini and evil mini is handled together.
-
-            //Neutrals
-            case CustomRoles.Agitater:
-                Agitater.ReceiveRPC(reader);
-                break;
-            case CustomRoles.Bandit:
-                Bandit.ReceiveRPC(reader);
-                break;
-            case CustomRoles.BloodKnight:
-                BloodKnight.ReceiveRPC(reader);
-                break;
-            case CustomRoles.Collector:
-                Collector.ReceiveRPC(reader);
-                break;
-            case CustomRoles.Doomsayer:
-                Doomsayer.ReceiveRPC(reader);
-                break;
-            case CustomRoles.Doppelganger:
-                Doppelganger.ReceiveRPC(reader);
-                break;
-            case CustomRoles.Demon:
-                Demon.ReceiveRPC(reader);
-                break;
-            case CustomRoles.Huntsman:
-                Huntsman.ReceiveRPC(reader);
-                break;
-            case CustomRoles.Imitator:
-                Imitator.ReceiveRPC(reader);
-                break;
-            case CustomRoles.Jackal:
-                Jackal.ReceiveRPC(reader);
-                break;
-            case CustomRoles.Lawyer:
-                Lawyer.ReceiveRPC(reader);
-                break;
-            case CustomRoles.Pelican:
-                Pelican.ReceiveRPC(reader);
-                break;
-            case CustomRoles.Pirate:
-                Pirate.ReceiveRPC(reader);
-                break;
-            case CustomRoles.Pixie:
-                Pixie.ReceiveRPC(reader);
-                break;
-            case CustomRoles.PlagueBearer:
-                PlagueBearer.ReceiveRPC(reader);
-                break;
-            case CustomRoles.PlagueDoctor:
-                PlagueDoctor.ReceiveRPC(reader);
-                break;
-            case CustomRoles.PotionMaster:
-                PotionMaster.ReceiveRPC(reader);
-                break;
-            case CustomRoles.Pursuer:
-                Pursuer.ReceiveRPC(reader);
-                break;
-            case CustomRoles.Quizmaster:
-                Quizmaster.ReceiveRPC(reader);
-                break;
-            case CustomRoles.Romantic:
-                Romantic.ReceiveRPC(reader);
-                break;
-            case CustomRoles.VengefulRomantic:
-                VengefulRomantic.ReceiveRPC(reader);
-                break;
-            case CustomRoles.SchrodingersCat:
-                SchrodingersCat.ReceiveRPC(reader);
-                break;
-            case CustomRoles.Seeker:
-                Seeker.ReceiveRPC(reader);
-                break;
-            case CustomRoles.Shroud:
-                Shroud.ReceiveRPC(reader);
-                break;
-            case CustomRoles.Solsticer:
-                Solsticer.ReceiveRPC(reader);
-                break;
-            case CustomRoles.SoulCollector:
-                SoulCollector.ReceiveRPC(reader);
-                break;
-            case CustomRoles.Spiritcaller:
-                Spiritcaller.ReceiveRPC(reader);
-                break;
-            case CustomRoles.Cultist:
-                Cultist.ReceiveRPC(reader);
-                break;
-            case CustomRoles.Taskinator:
-                Taskinator.ReceiveRPC(reader);
-                break;
-            case CustomRoles.Follower:
-                Follower.ReceiveRPC(reader);
-                break;
-            case CustomRoles.Virus:
-                Virus.ReceiveRPC(reader);
-                break;
-            case CustomRoles.Wraith:
-                Wraith.ReceiveRPC(reader);
-                break;
-
-            // Ghosts
-            case CustomRoles.Hawk:
-                Hawk.ReceiveRPC(reader);
-                break;
-             case CustomRoles.Bloodmoon:
-                 Bloodmoon.ReceiveRPC(reader);
-                break;
-            case CustomRoles.Warden:
-                Warden.ReceiveRPC(reader);
-                break;
-
-
             default:
-                Logger.Error($"Role {role} can not be handled!", "SyncRoleSkillReader");
+                role.IsRoleClass().ReceiveRPC(reader, pc);
                 break;
         }
     }

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -509,10 +509,8 @@ public static class Utils
         Main.RoleClass.Add(role, role.CreateRoleClass(IsToAccess: true));
         return Main.RoleClass[role];
     }
-    public static List<RoleBase> EnabledRoles()
-    {
-        return Main.RoleClass.Values.Where(x => x.IsEnable).ToList();
-    }
+    public static List<RoleBase> EnabledRoles => Main.RoleClass.Values.Where(x => x.IsEnable).ToList();
+    
     public static string GetProgressText(PlayerControl pc)
     {
         try

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -1867,7 +1867,7 @@ public static class Utils
 
             CurrentСolor = taskState.IsTaskFinished ? TaskCompleteColor : NonCompleteColor;
 
-            if (Main.PlayerStates.TryGetValue(id, out var ps) && ps.MainRole.Is(CustomRoles.Crewpostor))
+            if (Main.PlayerStates.TryGetValue(id, out var ps) && ps.MainRole is CustomRoles.Crewpostor)
                 CurrentСolor = Color.red;
 
             if (ps.SubRoles.Contains(CustomRoles.Workhorse))

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -1382,6 +1382,10 @@ public static class Utils
     {
         return Main.AllPlayerControls.FirstOrDefault(pc => pc.PlayerId == PlayerId);
     }
+    public static List<PlayerControl> GetPlayerListByIds(this IEnumerable<byte> PlayerIdList)
+    {
+        return PlayerIdList.Select(x => GetPlayerById(x)).ToList();
+    }
     public static GameData.PlayerInfo GetPlayerInfoById(int PlayerId) =>
         GameData.Instance.AllPlayers.ToArray().FirstOrDefault(info => info.PlayerId == PlayerId);
     private static readonly StringBuilder SelfSuffix = new();

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -509,6 +509,10 @@ public static class Utils
         Main.RoleClass.Add(role, role.CreateRoleClass(IsToAccess: true));
         return Main.RoleClass[role];
     }
+    public static List<RoleBase> EnabledRoles()
+    {
+        return Main.RoleClass.Values.Where(x => x.IsEnable).ToList();
+    }
     public static string GetProgressText(PlayerControl pc)
     {
         try

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -456,7 +456,7 @@ public static class Utils
         if (p.IsDead && Options.GhostIgnoreTasks.GetBool()) hasTasks = false;
         var role = States.MainRole;
 
-        if (!States.RoleClass.HasTasks(p.PlayerId, role))
+        if (!States.RoleClass.HasTasks(p, role, ForRecompute))
             hasTasks = false;
 
         switch (role)
@@ -464,22 +464,10 @@ public static class Utils
             case CustomRoles.GM:
                 hasTasks = false;
                 break;
-            case CustomRoles.Workaholic:
-            case CustomRoles.Terrorist:
             case CustomRoles.Sunnyboy:
-            case CustomRoles.Convict:
-            case CustomRoles.Opportunist:
-            case CustomRoles.Taskinator:
-            case CustomRoles.Phantom:
                 if (ForRecompute)
                     hasTasks = false;
                     break;
-            case CustomRoles.Crewpostor:
-                if (ForRecompute && !p.IsDead)
-                    hasTasks = false;
-                if (p.IsDead)
-                    hasTasks = false;
-                break;
             default:
                 if (role.IsImpostor() || role.IsNK()) hasTasks = false;
                 break;

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -1847,6 +1847,12 @@ public static class Utils
         ProcessStartInfo psi = new("Explorer.exe") { Arguments = "/e,/select," + @filename.Replace("/", "\\") };
         Process.Start(psi);
     }
+    /// <summary>
+    /// Return the first byte of a HashSet(Byte)
+    /// </summary>
+    public static byte First(this HashSet<byte> source)
+        => source.ToArray().First();
+    
     public static string SummaryTexts(byte id, bool disableColor = true, bool check = false)
     {
         var name = Main.AllPlayerNames[id].RemoveHtmlTags().Replace("\r\n", string.Empty);

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -1384,7 +1384,7 @@ public static class Utils
     }
     public static List<PlayerControl> GetPlayerListByIds(this IEnumerable<byte> PlayerIdList)
     {
-        return PlayerIdList.Select(x => GetPlayerById(x)).ToList();
+        return PlayerIdList.ToList().Select(x => GetPlayerById(x)).ToList();
     }
     public static GameData.PlayerInfo GetPlayerInfoById(int PlayerId) =>
         GameData.Instance.AllPlayers.ToArray().FirstOrDefault(info => info.PlayerId == PlayerId);

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -509,7 +509,6 @@ public static class Utils
         Main.RoleClass.Add(role, role.CreateRoleClass(IsToAccess: true));
         return Main.RoleClass[role];
     }
-    public static List<RoleBase> EnabledRoles => Main.RoleClass.Values.Where(x => x.IsEnable).ToList();
     
     public static string GetProgressText(PlayerControl pc)
     {

--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -46,7 +46,7 @@ internal class ChatCommands
         var cancelVal = "";
         Main.isChatCommand = true;
         Logger.Info(text, "SendChat");
-        if ((Options.NewHideMsg.GetBool() || Blackmailer.On) && AmongUsClient.Instance.AmHost) // Blackmailer.ForBlackmailer.Contains(PlayerControl.LocalPlayer.PlayerId)) && PlayerControl.LocalPlayer.IsAlive())
+        if ((Options.NewHideMsg.GetBool() || Blackmailer.HasEnabled) && AmongUsClient.Instance.AmHost) // Blackmailer.ForBlackmailer.Contains(PlayerControl.LocalPlayer.PlayerId)) && PlayerControl.LocalPlayer.IsAlive())
         {
             ChatManager.SendMessage(PlayerControl.LocalPlayer, text);
         }
@@ -1456,7 +1456,7 @@ internal class ChatCommands
     {
         canceled = false;
         if (!AmongUsClient.Instance.AmHost) return;
-        if ((Options.NewHideMsg.GetBool() || Blackmailer.On) && player.PlayerId != 0) // Blackmailer.ForBlackmailer.Contains(player.PlayerId)) && PlayerControl.LocalPlayer.IsAlive() && player.PlayerId != 0)
+        if ((Options.NewHideMsg.GetBool() || Blackmailer.HasEnabled) && player.PlayerId != 0) // Blackmailer.ForBlackmailer.Contains(player.PlayerId)) && PlayerControl.LocalPlayer.IsAlive() && player.PlayerId != 0)
         {
             ChatManager.SendMessage(player, text);
         }

--- a/Patches/PlayerControlPatch.cs
+++ b/Patches/PlayerControlPatch.cs
@@ -1492,7 +1492,7 @@ public static class PlayerControlDiePatch
     {
         if (!AmongUsClient.Instance.AmHost) return;
 
-        Utils.EnabledRoles().Do(x => x.OnOtherTargetsReducedToAtoms(__instance));
+        Utils.EnabledRoles.Do(x => x.OnOtherTargetsReducedToAtoms(__instance));
 
         __instance.RpcRemovePet();
     }

--- a/Patches/PlayerControlPatch.cs
+++ b/Patches/PlayerControlPatch.cs
@@ -1492,7 +1492,7 @@ public static class PlayerControlDiePatch
     {
         if (!AmongUsClient.Instance.AmHost) return;
 
-        Main.EnabledRoles.Do(x => x.OnOtherTargetsReducedToAtoms(__instance));
+        Utils.EnabledRoles().Do(x => x.OnOtherTargetsReducedToAtoms(__instance));
 
         __instance.RpcRemovePet();
     }

--- a/Patches/PlayerControlPatch.cs
+++ b/Patches/PlayerControlPatch.cs
@@ -1492,7 +1492,7 @@ public static class PlayerControlDiePatch
     {
         if (!AmongUsClient.Instance.AmHost) return;
 
-        Utils.EnabledRoles.Do(x => x.OnOtherTargetsReducedToAtoms(__instance));
+        Main.EnabledRoles.Do(x => x.OnOtherTargetsReducedToAtoms(__instance));
 
         __instance.RpcRemovePet();
     }

--- a/Patches/PlayerControlPatch.cs
+++ b/Patches/PlayerControlPatch.cs
@@ -521,7 +521,7 @@ class RpcMurderPlayerPatch
         var killer = target.GetRealKiller();
 
         if (!killer.RpcCheckAndMurder(target, check: true) && !killer.Is(CustomRoles.Pestilence))
-            Logger.Warn($" Killer: {killer.GetRealName} murdered {target.GetRealName()} while target was under protection", "RpcMurderPlayer");
+            Logger.Warn($" Killer: {killer.GetRealName} murdered {target.GetRealName()} while target was under protection", "RpcMurderPlayerPatch..Prefix");
 
         return false;
         // There is no need to include DecisionByHost. DecisionByHost will make client check protection locally and cause confusion.

--- a/Patches/PlayerControlPatch.cs
+++ b/Patches/PlayerControlPatch.cs
@@ -135,7 +135,7 @@ class CheckMurderPatch
         }
 
         // Set kill cooldown for Chronomancer
-        if (killerRole.Is(CustomRoles.Chronomancer))
+        if (killerRole is CustomRoles.Chronomancer)
             Chronomancer.OnCheckMurder(killer);
 
         killer.ResetKillCooldown();

--- a/Patches/PlayerControlPatch.cs
+++ b/Patches/PlayerControlPatch.cs
@@ -141,7 +141,7 @@ class CheckMurderPatch
         killer.ResetKillCooldown();
 
         // Replacement process when the actual killer and the KILLER are different
-        if (Sniper.On)
+        if (Sniper.HasEnabled)
         {
             Sniper.TryGetSniper(target.PlayerId, ref killer);
             

--- a/Patches/PlayerControlPatch.cs
+++ b/Patches/PlayerControlPatch.cs
@@ -1490,8 +1490,7 @@ public static class PlayerControlDiePatch
     {
         if (!AmongUsClient.Instance.AmHost) return;
 
-        Main.RoleClass.Values.Where(RoleBase => RoleBase.IsEnable)
-            .Do(x => x.OnOtherTargetsReducedToAtoms(__instance));
+        Main.EnabledRoles.Do(x => x.OnOtherTargetsReducedToAtoms(__instance));
 
         __instance.RpcRemovePet();
     }

--- a/Patches/PlayerControlPatch.cs
+++ b/Patches/PlayerControlPatch.cs
@@ -1575,6 +1575,7 @@ class PlayerControlSetRolePatch
 
         if (roleType == RoleTypes.GuardianAngel && !DidSetGhost.ContainsKey(__instance.PlayerId)) 
         {
+            Utils.NotifyRoles(SpecifyTarget: __instance); //Update rolename for vanilla
             _ = new LateTask(() => { 
                 
                 __instance.RpcResetAbilityCooldown();

--- a/Patches/PlayerControlPatch.cs
+++ b/Patches/PlayerControlPatch.cs
@@ -519,6 +519,8 @@ class RpcMurderPlayerPatch
         AmongUsClient.Instance.FinishRpcImmediately(messageWriter);
 
         var killer = target.GetRealKiller();
+        if (target.Is(CustomRoles.Susceptible))
+            Susceptible.CallEnabledAndChange(target);
 
         if (!killer.RpcCheckAndMurder(target, check: true) && !killer.Is(CustomRoles.Pestilence))
             Logger.Warn($" Killer: {killer.GetRealName} murdered {target.GetRealName()} while target was under protection", "RpcMurderPlayerPatch..Prefix");

--- a/Patches/PlayerControlPatch.cs
+++ b/Patches/PlayerControlPatch.cs
@@ -362,6 +362,18 @@ class CheckMurderPatch
         return true;
     }
 }
+[HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.RpcMurderPlayer))]
+class CheckSuccessMurder
+{
+    public static void Postfix([HarmonyArgument(0)] PlayerControl target)
+    {
+        var killer = target.GetRealKiller();
+
+        if (!killer.RpcCheckAndMurder(target, check: true) && !killer.Is(CustomRoles.Pestilence)) // Probably can just cancel it here lol
+            Logger.Warn($" Killer: {killer.GetRealName} murdered {target.GetRealName()} while target was under protection", "RpcMurderPlayer");
+
+    }
+}
 
 [HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.MurderPlayer))]
 class MurderPlayerPatch

--- a/Patches/PlayerControlPatch.cs
+++ b/Patches/PlayerControlPatch.cs
@@ -362,18 +362,6 @@ class CheckMurderPatch
         return true;
     }
 }
-[HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.RpcMurderPlayer))]
-class CheckSuccessMurder
-{
-    public static void Postfix([HarmonyArgument(0)] PlayerControl target)
-    {
-        var killer = target.GetRealKiller();
-
-        if (!killer.RpcCheckAndMurder(target, check: true) && !killer.Is(CustomRoles.Pestilence)) // Probably can just cancel it here lol
-            Logger.Warn($" Killer: {killer.GetRealName} murdered {target.GetRealName()} while target was under protection", "RpcMurderPlayer");
-
-    }
-}
 
 [HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.MurderPlayer))]
 class MurderPlayerPatch
@@ -529,6 +517,11 @@ class RpcMurderPlayerPatch
         messageWriter.WriteNetObject(target);
         messageWriter.Write((int)murderResultFlags);
         AmongUsClient.Instance.FinishRpcImmediately(messageWriter);
+
+        var killer = target.GetRealKiller();
+
+        if (!killer.RpcCheckAndMurder(target, check: true) && !killer.Is(CustomRoles.Pestilence))
+            Logger.Warn($" Killer: {killer.GetRealName} murdered {target.GetRealName()} while target was under protection", "RpcMurderPlayer");
 
         return false;
         // There is no need to include DecisionByHost. DecisionByHost will make client check protection locally and cause confusion.

--- a/Patches/PlayerControlPatch.cs
+++ b/Patches/PlayerControlPatch.cs
@@ -1581,7 +1581,7 @@ class PlayerControlSetRolePatch
 
         if (roleType == RoleTypes.GuardianAngel && !DidSetGhost.ContainsKey(__instance.PlayerId)) 
         {
-            Utils.NotifyRoles(SpecifyTarget: __instance); //Update rolename for vanilla
+            Utils.NotifyRoles(SpecifyTarget: __instance, NoCache: true); //Update rolename for vanilla
             _ = new LateTask(() => { 
                 
                 __instance.RpcResetAbilityCooldown();

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -71,7 +71,6 @@ internal class ChangeRoleSettings
             Main.LastNotifyNames.Clear();
             Main.PlayerColors.Clear();
 
-            Main.EnabledRoles.Clear();
             Main.ShieldPlayer = Options.ShieldPersonDiedFirst.GetBool() ? Main.FirstDied : "";
             Main.FirstDied = "";
             Main.MadmateNum = 0;
@@ -404,7 +403,6 @@ internal class SelectRolesPatch
             {
                 if (pc.Data.Role.Role == RoleTypes.Shapeshifter) Main.CheckShapeshift.Add(pc.PlayerId, false);
 
-                Main.EnabledRoles.Add(pc.GetRoleClass());
                 pc.GetRoleClass()?.Add(pc.PlayerId);
 
                 foreach (var subRole in pc.GetCustomSubRoles().ToArray())

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -71,6 +71,7 @@ internal class ChangeRoleSettings
             Main.LastNotifyNames.Clear();
             Main.PlayerColors.Clear();
 
+            Main.EnabledRoles.Clear();
             Main.ShieldPlayer = Options.ShieldPersonDiedFirst.GetBool() ? Main.FirstDied : "";
             Main.FirstDied = "";
             Main.MadmateNum = 0;
@@ -403,6 +404,7 @@ internal class SelectRolesPatch
             {
                 if (pc.Data.Role.Role == RoleTypes.Shapeshifter) Main.CheckShapeshift.Add(pc.PlayerId, false);
 
+                Main.EnabledRoles.Add(pc.GetRoleClass());
                 pc.GetRoleClass()?.Add(pc.PlayerId);
 
                 foreach (var subRole in pc.GetCustomSubRoles().ToArray())

--- a/Resources/Lang/en_US.json
+++ b/Resources/Lang/en_US.json
@@ -63,6 +63,7 @@
   "ShowOnlyEnabledRolesInGuesserUI": "Show Only Enabled Roles In Guesser UI",
   "CrewCanGuessCrew": "<color=#8cffff>Crewmates</color> Can Guess <color=#8cffff>Crewmate</color> Roles",
   "ImpCanGuessImp": "<color=#ff1919>Impostors</color> Can Guess <color=#ff1919>Impostor</color> Roles",
+  "GuessImmune": "Sorry, but target is immune to being guessed!",
 
 
   "GM": "Game Master",

--- a/Roles/(Ghosts)/Crewmate/Hawk.cs
+++ b/Roles/(Ghosts)/Crewmate/Hawk.cs
@@ -90,7 +90,7 @@ internal class Hawk : RoleBase
         writer.Write(KillCount[playerId]);
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         byte PlayerId = reader.ReadByte();
         int Limit = reader.ReadInt32();

--- a/Roles/(Ghosts)/Crewmate/Warden.cs
+++ b/Roles/(Ghosts)/Crewmate/Warden.cs
@@ -50,7 +50,7 @@ internal class Warden : RoleBase
         writer.Write(AbilityCount[playerId]);
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         byte PlayerId = reader.ReadByte();
         int Limit = reader.ReadInt32();

--- a/Roles/(Ghosts)/Impostor/Bloodmoon.cs
+++ b/Roles/(Ghosts)/Impostor/Bloodmoon.cs
@@ -63,7 +63,7 @@ internal class Bloodmoon : RoleBase
         writer.Write(KillCount[playerId]);
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         byte PlayerId = reader.ReadByte();
         int Limit = reader.ReadInt32();

--- a/Roles/AddOns/Common/Necroview.cs
+++ b/Roles/AddOns/Common/Necroview.cs
@@ -24,12 +24,12 @@ public static class Necroview
 
         foreach (var SubRole in target.GetCustomSubRoles())
         {
-            if (SubRole.Is(CustomRoles.Charmed)
-                || SubRole.Is(CustomRoles.Infected)
-                || SubRole.Is(CustomRoles.Contagious)
-                || SubRole.Is(CustomRoles.Egoist)
-                || SubRole.Is(CustomRoles.Recruit)
-                || SubRole.Is(CustomRoles.Soulless))
+            if (SubRole is CustomRoles.Charmed
+                or CustomRoles.Infected
+                or CustomRoles.Contagious
+                or CustomRoles.Egoist
+                or CustomRoles.Recruit
+                or CustomRoles.Soulless)
                 return Main.roleColors[CustomRoles.Knight];
         }
 

--- a/Roles/AddOns/Common/Susceptible.cs
+++ b/Roles/AddOns/Common/Susceptible.cs
@@ -54,7 +54,7 @@ public class Susceptible
                     break;
 
                 case PlayerState.DeathReason.Spell:
-                    if (!Witch.On)
+                    if (!Witch.HasEnabled)
                     {
                         Main.PlayerStates[victim.PlayerId].deathReason = PlayerState.DeathReason.Kill;
                     }
@@ -133,7 +133,7 @@ public class Susceptible
                     break;
 
                 case PlayerState.DeathReason.Bombed:
-                    if (!Bomber.On && !Burst.IsEnable && !Trapster.On && !Fireworker.On)
+                    if (!Bomber.HasEnabled && !Burst.IsEnable && !Trapster.HasEnabled && !Fireworker.HasEnabled)
                     {
                         Main.PlayerStates[victim.PlayerId].deathReason = PlayerState.DeathReason.Kill;
                     }
@@ -166,7 +166,7 @@ public class Susceptible
                     break;
 
                 case PlayerState.DeathReason.Sniped:
-                    if (!Sniper.On)
+                    if (!Sniper.HasEnabled)
                     {
                         Main.PlayerStates[victim.PlayerId].deathReason = PlayerState.DeathReason.Kill;
                     }
@@ -199,7 +199,7 @@ public class Susceptible
                     break;
 
                 case PlayerState.DeathReason.Quantization:
-                    if (!Lightning.On)
+                    if (!Lightning.HasEnabled)
                     {
                         Main.PlayerStates[victim.PlayerId].deathReason = PlayerState.DeathReason.Kill;
                     }
@@ -254,7 +254,7 @@ public class Susceptible
                     break;
 
                 case PlayerState.DeathReason.LossOfHead:
-                    if (!Hangman.On)
+                    if (!Hangman.HasEnabled)
                     {
                         Main.PlayerStates[victim.PlayerId].deathReason = PlayerState.DeathReason.Kill;
                     }
@@ -265,7 +265,7 @@ public class Susceptible
                     break;
 
                 case PlayerState.DeathReason.Trialed:
-                    if (!Judge.HasEnabled && !Councillor.On)
+                    if (!Judge.HasEnabled && !Councillor.HasEnabled)
                     {
                         Main.PlayerStates[victim.PlayerId].deathReason = PlayerState.DeathReason.Kill;
                     }

--- a/Roles/Core/AssignManager/GhostRoleAssign.cs
+++ b/Roles/Core/AssignManager/GhostRoleAssign.cs
@@ -83,6 +83,7 @@ public static class GhostRoleAssign
             {
                 CrewCount++;
                 getCount[ChosenRole]--; // Only deduct if role has been set.
+                player.GetRoleClass().Remove(player.PlayerId);
                 player.RpcSetCustomRole(ChosenRole);
                 player.GetRoleClass().Add(player.PlayerId);
             }
@@ -102,6 +103,7 @@ public static class GhostRoleAssign
             {
                 ImpCount++;
                 getCount[ChosenRole]--;
+                player.GetRoleClass().Remove(player.PlayerId);
                 player.RpcSetCustomRole(ChosenRole);
                 player.GetRoleClass().Add(player.PlayerId);
             }

--- a/Roles/Core/AssignManager/GhostRoleAssign.cs
+++ b/Roles/Core/AssignManager/GhostRoleAssign.cs
@@ -14,12 +14,15 @@ namespace TOHE.Roles.Core.AssignManager;
 public static class GhostRoleAssign
 {
     public static Dictionary<byte, CustomRoles> GhostGetPreviousRole = [];
-    private static Dictionary<CustomRoles, int> getCount = [];
+    private static readonly Dictionary<CustomRoles, int> getCount = [];
 
     private static readonly IRandom Rnd = IRandom.Instance;
     private static bool GetChance(this CustomRoles role) => role.GetMode() == 100 || Rnd.Next(1, 100) <= role.GetMode();
     private static int ImpCount = 0;
     private static int CrewCount = 0;
+
+    private static readonly List<CustomRoles> HauntedList = [];
+    private static readonly List<CustomRoles> ImpHauntedList = [];
     public static void GhostAssignPatch(PlayerControl player)
     {
         if (GameStates.IsHideNSeek || player == null || player.Data.Disconnected || GhostGetPreviousRole.ContainsKey(player.PlayerId)) return;
@@ -27,17 +30,18 @@ public static class GhostRoleAssign
         var getplrRole = player.GetCustomRole();
         if (getplrRole is CustomRoles.GM or CustomRoles.Nemesis or CustomRoles.Retributionist) return;
 
-        var IsCrewmate = getplrRole.IsCrewmate() && (!player.IsAnySubRole(x => x.IsConverted() || Options.ConvertedCanBecomeGhost.GetBool()));
-        var IsImpostor = getplrRole.IsImpostor() && (!player.IsAnySubRole(x => x.IsConverted() || Options.ConvertedCanBecomeGhost.GetBool()));
+        var IsNeutralAllowed = !player.IsAnySubRole(x => x.IsConverted() || x is CustomRoles.Madmate) || Options.ConvertedCanBecomeGhost.GetBool();
+        var IsCrewmate = getplrRole.IsCrewmate() && IsNeutralAllowed;
+        var IsImpostor = getplrRole.IsImpostor() && IsNeutralAllowed;
 
         if (getplrRole.IsGhostRole() || player.IsAnySubRole(x => x.IsGhostRole() || x == CustomRoles.Gravestone) || Options.CustomGhostRoleCounts.Count <= 0) return;
 
-        if (ImpCount >= Options.MaxImpGhost.GetInt() || CrewCount >= Options.MaxCrewGhost.GetInt()) return;
+        if (IsImpostor && ImpCount >= Options.MaxImpGhost.GetInt() || IsCrewmate && CrewCount >= Options.MaxCrewGhost.GetInt()) return;
 
             GhostGetPreviousRole.TryAdd(player.PlayerId, getplrRole);
 
-        List<CustomRoles> HauntedList = [];
-        List<CustomRoles> ImpHauntedList = [];
+        HauntedList.Clear();
+        ImpHauntedList.Clear();
 
         CustomRoles ChosenRole = CustomRoles.NotAssigned;
 
@@ -80,9 +84,7 @@ public static class GhostRoleAssign
                 CrewCount++;
                 getCount[ChosenRole]--; // Only deduct if role has been set.
                 player.RpcSetCustomRole(ChosenRole);
-                // player.RpcSetRole(RoleTypes.GuardianAngel); 
                 player.GetRoleClass().Add(player.PlayerId);
-                // player.RpcResetAbilityCooldown();
             }
             return;
         }
@@ -101,9 +103,7 @@ public static class GhostRoleAssign
                 ImpCount++;
                 getCount[ChosenRole]--;
                 player.RpcSetCustomRole(ChosenRole);
-                // player.RpcSetRole(RoleTypes.GuardianAngel);
                 player.GetRoleClass().Add(player.PlayerId);
-                // player.RpcResetAbilityCooldown();
             }
             return;
         }

--- a/Roles/Core/CustomRoleManager.cs
+++ b/Roles/Core/CustomRoleManager.cs
@@ -73,7 +73,7 @@ public static class CustomRoleManager
     /// </summary>
     public static bool OnCheckMurderAsTargetOnOthers(PlayerControl killer, PlayerControl target)
     {
-        return !Utils.EnabledRoles.Any(RoleClass => RoleClass.CheckMurderOnOthersTarget(killer, target));
+        return !Main.EnabledRoles.Any(RoleClass => RoleClass.CheckMurderOnOthersTarget(killer, target));
     }
 
     /// <summary>

--- a/Roles/Core/CustomRoleManager.cs
+++ b/Roles/Core/CustomRoleManager.cs
@@ -73,7 +73,7 @@ public static class CustomRoleManager
     /// </summary>
     public static bool OnCheckMurderAsTargetOnOthers(PlayerControl killer, PlayerControl target)
     {
-        return !Utils.EnabledRoles().Any(RoleClass => RoleClass.CheckMurderOnOthersTarget(killer, target));
+        return !Utils.EnabledRoles.Any(RoleClass => RoleClass.CheckMurderOnOthersTarget(killer, target));
     }
 
     /// <summary>

--- a/Roles/Core/CustomRoleManager.cs
+++ b/Roles/Core/CustomRoleManager.cs
@@ -73,7 +73,7 @@ public static class CustomRoleManager
     /// </summary>
     public static bool OnCheckMurderAsTargetOnOthers(PlayerControl killer, PlayerControl target)
     {
-        return !Main.EnabledRoles.Any(RoleClass => RoleClass.CheckMurderOnOthersTarget(killer, target));
+        return !Utils.EnabledRoles().Any(RoleClass => RoleClass.CheckMurderOnOthersTarget(killer, target));
     }
 
     /// <summary>

--- a/Roles/Core/CustomRoleManager.cs
+++ b/Roles/Core/CustomRoleManager.cs
@@ -73,18 +73,7 @@ public static class CustomRoleManager
     /// </summary>
     public static bool OnCheckMurderAsTargetOnOthers(PlayerControl killer, PlayerControl target)
     {
-        bool cancel = false;
-        foreach (var player in Main.AllAlivePlayerControls)
-        {
-            var playerRoleClass = player.GetRoleClass();
-            if (player == null || playerRoleClass == null) continue;
-
-            if (!playerRoleClass.CheckMurderOnOthersTarget(killer, target))
-            {
-                cancel = true;
-            }
-        }
-        return !cancel;
+        return !Main.EnabledRoles.Any(RoleClass => RoleClass.CheckMurderOnOthersTarget(killer, target));
     }
 
     /// <summary>

--- a/Roles/Core/RoleBase.cs
+++ b/Roles/Core/RoleBase.cs
@@ -166,7 +166,7 @@ public abstract class RoleBase
     /// A method to always check the state when target has died (murder, exiled, execute etc..)
     /// </summary>
     public virtual void OnOtherTargetsReducedToAtoms(PlayerControl DeadPlayer)
-    { }//
+    { }
 
     /// <summary>
     /// When the target role died and need run kill flash

--- a/Roles/Core/RoleBase.cs
+++ b/Roles/Core/RoleBase.cs
@@ -1,4 +1,5 @@
 ﻿using AmongUs.GameOptions;
+using Hazel;
 using InnerNet;
 using System.Collections.Generic;
 using TOHE.Roles.AddOns.Common;
@@ -77,7 +78,7 @@ public abstract class RoleBase
     /// </summary>
     public virtual void OnFixedUpdateLowLoad(PlayerControl pc)
     { }
-    
+
     /// <summary>
     /// Player completes a task
     /// </summary>
@@ -312,4 +313,8 @@ public abstract class RoleBase
     public virtual bool KnowRoleTarget(PlayerControl seer, PlayerControl target) => false;
     public virtual string PlayerKnowTargetColor(PlayerControl seer, PlayerControl target) => string.Empty;
     public virtual bool OthersKnowTargetRoleColor(PlayerControl seer, PlayerControl target) => false;
+    public virtual void ReceiveRPC(MessageReader reader, PlayerControl pc)
+    {
+        Logger.Error($"Role {(CustomRoles)reader.ReadPackedInt32()} can not be handled!", "SyncRoleSkillReader");
+    }
 }

--- a/Roles/Core/RoleBase.cs
+++ b/Roles/Core/RoleBase.cs
@@ -92,7 +92,7 @@ public abstract class RoleBase
     // <summary>
     /// The role's tasks are needed for a task win
     /// </summary>
-    public virtual bool HasTasks(byte player, CustomRoles role) => role.IsCrewmate() && !role.IsTasklessCrewmate();
+    public virtual bool HasTasks(GameData.PlayerInfo player, CustomRoles role, bool ForRecompute) => role.IsCrewmate() && !role.IsTasklessCrewmate() && (ForRecompute ? !player.Object.IsAnySubRole(x => x.IsConverted()) : true);
     /// <summary>
     /// A generic method to check a Guardian Angel protecting someone.
     /// </summary>

--- a/Roles/Core/RoleBase.cs
+++ b/Roles/Core/RoleBase.cs
@@ -166,7 +166,7 @@ public abstract class RoleBase
     /// A method to always check the state when target has died (murder, exiled, execute etc..)
     /// </summary>
     public virtual void OnOtherTargetsReducedToAtoms(PlayerControl DeadPlayer)
-    { }
+    { }//
 
     /// <summary>
     /// When the target role died and need run kill flash

--- a/Roles/Crewmate/Bodyguard.cs
+++ b/Roles/Crewmate/Bodyguard.cs
@@ -35,7 +35,7 @@ internal class Bodyguard : RoleBase
     }
     public override bool CheckMurderOnOthersTarget(PlayerControl killer, PlayerControl target)
     {
-        if (killer.PlayerId == target.PlayerId || playerIdList.Count <= 0) return true;
+        if (killer?.PlayerId == target.PlayerId || playerIdList.Count <= 0) return true;
 
         foreach (var bodyguardId in playerIdList.ToArray())
         {

--- a/Roles/Crewmate/Captain.cs
+++ b/Roles/Crewmate/Captain.cs
@@ -196,7 +196,7 @@ internal class Captain : RoleBase
     }
     public override void OnPlayerExiled(PlayerControl captain, GameData.PlayerInfo exiled)
     {
-        if (exiled == null || !exiled.GetCustomRole().Is(CustomRoles.Captain)) return;
+        if (exiled == null || (exiled.GetCustomRole() is not CustomRoles.Captain)) return;
 
         byte playerId = exiled.PlayerId;
         if (playerId == byte.MaxValue) return;

--- a/Roles/Crewmate/Chameleon.cs
+++ b/Roles/Crewmate/Chameleon.cs
@@ -80,7 +80,7 @@ internal class Chameleon : RoleBase
             AmongUsClient.Instance.FinishRpcImmediately(writer);
         }
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         byte pid = reader.ReadByte();
         bool isLimit = reader.ReadBoolean();

--- a/Roles/Crewmate/ChiefOfPolice.cs
+++ b/Roles/Crewmate/ChiefOfPolice.cs
@@ -95,7 +95,7 @@ public static class ChiefOfPolice
         {
             //if (ChiefOfPoliceCountMode.GetInt() == 1)
             //{
-            //    killer.RpcMurderPlayerV3(killer);
+            //    killer.RpcMurderPlayer(killer);
             //    return true;
             //}
             //if (ChiefOfPoliceCountMode.GetInt() == 2)

--- a/Roles/Crewmate/Cleanser.cs
+++ b/Roles/Crewmate/Cleanser.cs
@@ -82,7 +82,7 @@ internal class Cleanser : RoleBase
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
 
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         byte CleanserId = reader.ReadByte();
         int Limit = reader.ReadInt32();

--- a/Roles/Crewmate/Coroner.cs
+++ b/Roles/Crewmate/Coroner.cs
@@ -91,7 +91,7 @@ internal class Coroner : RoleBase
         if (operate != 2) writer.Write(targetId);
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPCLimit(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         byte pid = reader.ReadByte();
         int opt = reader.ReadInt32();

--- a/Roles/Crewmate/Crusader.cs
+++ b/Roles/Crewmate/Crusader.cs
@@ -63,7 +63,7 @@ internal class Crusader : RoleBase
         writer.Write(CrusaderLimit[playerId]);
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         byte PlayerId = reader.ReadByte();
         int Limit = reader.ReadInt32();

--- a/Roles/Crewmate/Crusader.cs
+++ b/Roles/Crewmate/Crusader.cs
@@ -118,7 +118,7 @@ internal class Crusader : RoleBase
             if (killer.Is(CustomRoles.Pestilence))
             {
                 Main.PlayerStates[crusader.PlayerId].deathReason = PlayerState.DeathReason.PissedOff;
-                killer.RpcMurderPlayerV3(crusader);
+                killer.RpcMurderPlayer(crusader);
                 ForCrusade.Remove(target.PlayerId);
                 target.RpcGuardAndKill(killer);
 

--- a/Roles/Crewmate/Deceiver.cs
+++ b/Roles/Crewmate/Deceiver.cs
@@ -64,7 +64,7 @@ internal class Deceiver : RoleBase
         writer.Write(SeelLimit[playerId]);
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         byte PlayerId = reader.ReadByte();
         int Limit = reader.ReadInt32();

--- a/Roles/Crewmate/Deceiver.cs
+++ b/Roles/Crewmate/Deceiver.cs
@@ -132,7 +132,7 @@ internal class Deceiver : RoleBase
         if (killer == null) return false;
         
         Main.PlayerStates[target.PlayerId].deathReason = PlayerState.DeathReason.Misfire;
-        target.RpcMurderPlayerV3(target);
+        target.RpcMurderPlayer(target);
         target.SetRealKiller(killer);
 
         Logger.Info($"The customer {target.GetRealName()} of {pc.GetRealName()}, a counterfeiter, commits suicide by using counterfeits", "Deceiver");

--- a/Roles/Crewmate/Deputy.cs
+++ b/Roles/Crewmate/Deputy.cs
@@ -59,7 +59,7 @@ internal class Deputy : RoleBase
         writer.Write(HandcuffLimit);
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         HandcuffLimit = reader.ReadInt32();
     }

--- a/Roles/Crewmate/FortuneTeller.cs
+++ b/Roles/Crewmate/FortuneTeller.cs
@@ -87,7 +87,7 @@ internal class FortuneTeller : RoleBase
         }
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         bool isTemp = reader.ReadBoolean();
         byte playerId = reader.ReadByte();

--- a/Roles/Crewmate/Knight.cs
+++ b/Roles/Crewmate/Knight.cs
@@ -65,7 +65,7 @@ internal class Knight : RoleBase
         writer.Write(playerId);
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         byte KnightId = reader.ReadByte();
         if (!killed.Contains(KnightId))

--- a/Roles/Crewmate/Mechanic.cs
+++ b/Roles/Crewmate/Mechanic.cs
@@ -175,7 +175,7 @@ internal class Mechanic : RoleBase
         writer.Write(UsedSkillCount[playerId]);
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         byte playerId = reader.ReadByte();
         float count = reader.ReadSingle();

--- a/Roles/Crewmate/Medic.cs
+++ b/Roles/Crewmate/Medic.cs
@@ -99,7 +99,7 @@ internal class Medic : RoleBase
         writer.Write(ProtectLimit[playerId]);
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         byte PlayerId = reader.ReadByte();
         int Limit = reader.ReadInt32();

--- a/Roles/Crewmate/Medium.cs
+++ b/Roles/Crewmate/Medium.cs
@@ -71,7 +71,7 @@ internal class Medium : RoleBase
         if (isUsed) writer.Write(targetId);
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         byte pid = reader.ReadByte();
         float limit = reader.ReadSingle();

--- a/Roles/Crewmate/Monarch.cs
+++ b/Roles/Crewmate/Monarch.cs
@@ -56,7 +56,7 @@ internal class Monarch : RoleBase
         writer.Write(KnightLimit);
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         KnightLimit = reader.ReadInt32();
     }

--- a/Roles/Crewmate/Oracle.cs
+++ b/Roles/Crewmate/Oracle.cs
@@ -76,7 +76,7 @@ internal class Oracle : RoleBase
         else writer.Write(TempCheckLimit[playerId]);
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         byte pid = reader.ReadByte();
         bool isTemp = reader.ReadBoolean();

--- a/Roles/Crewmate/Randomizer.cs
+++ b/Roles/Crewmate/Randomizer.cs
@@ -114,7 +114,7 @@ internal class Randomizer : RoleBase
                 {
                     Main.PlayerStates[rp.PlayerId].deathReason = PlayerState.DeathReason.Revenge;
                     rp.SetRealKiller(target);
-                    rp.RpcMurderPlayerV3(rp);
+                    rp.RpcMurderPlayer(rp);
                 }
             }
         }

--- a/Roles/Crewmate/Retributionist.cs
+++ b/Roles/Crewmate/Retributionist.cs
@@ -185,7 +185,7 @@ internal class Retributionist : RoleBase
             }
             else
             {
-                target.RpcMurderPlayerV3(target);
+                target.RpcMurderPlayer(target);
                 NotifyRoles(NoCache: true);
             }
             target.SetRealKiller(pc);

--- a/Roles/Crewmate/Retributionist.cs
+++ b/Roles/Crewmate/Retributionist.cs
@@ -166,6 +166,12 @@ internal class Retributionist : RoleBase
             else pc.ShowPopUp(GetString("GuessSolsticer"));
             return true;
         }
+        else if (!pc.RpcCheckAndMurder(target, true))
+        {
+            if (!isUI) SendMessage(GetString("GuessImmune"), pc.PlayerId);
+            else pc.ShowPopUp(GetString("GuessImmune"));
+            return true;
+        }
 
         Logger.Info($"{pc.GetNameWithRole()} 复仇了 {target.GetNameWithRole()}", "Retributionist");
 

--- a/Roles/Crewmate/Reverie.cs
+++ b/Roles/Crewmate/Reverie.cs
@@ -92,7 +92,7 @@ internal class Reverie : RoleBase
         if (NowCooldown[killer.PlayerId] >= MaxKillCooldown.GetFloat() && MisfireSuicide.GetBool())
         {
             Main.PlayerStates[killer.PlayerId].deathReason = PlayerState.DeathReason.Misfire;
-            killer.RpcMurderPlayerV3(killer);
+            killer.RpcMurderPlayer(killer);
         }
         return true;
     }

--- a/Roles/Crewmate/Sheriff.cs
+++ b/Roles/Crewmate/Sheriff.cs
@@ -156,7 +156,7 @@ internal class Sheriff : RoleBase
             return true;
         }
         Main.PlayerStates[killer.PlayerId].deathReason = PlayerState.DeathReason.Misfire;
-        killer.RpcMurderPlayerV3(killer);
+        killer.RpcMurderPlayer(killer);
         return MisfireKillsTarget.GetBool();
     }
     public override string GetProgressText(byte playerId, bool computervirus)

--- a/Roles/Crewmate/Sheriff.cs
+++ b/Roles/Crewmate/Sheriff.cs
@@ -123,7 +123,7 @@ internal class Sheriff : RoleBase
         writer.Write(ShotLimit[playerId]);
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         byte SheriffId = reader.ReadByte();
         int Limit = reader.ReadInt32();

--- a/Roles/Crewmate/Swapper.cs
+++ b/Roles/Crewmate/Swapper.cs
@@ -375,7 +375,7 @@ internal class Swapper : RoleBase
         byte PlayerId = reader.ReadByte();
         SwapMsg(pc, $"/sw {PlayerId}");
     }
-    public static void ReceiveSkillRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         byte playerId = reader.ReadByte();
         int skillLimit = reader.ReadInt32();

--- a/Roles/Crewmate/Veteran.cs
+++ b/Roles/Crewmate/Veteran.cs
@@ -69,14 +69,14 @@ internal class Veteran : RoleBase
                 if (!killer.Is(CustomRoles.Pestilence))
                 {
                     killer.SetRealKiller(target);
-                    target.RpcMurderPlayerV3(killer);
+                    target.RpcMurderPlayer(killer);
                     Logger.Info($"{target.GetRealName()} 老兵反弹击杀：{killer.GetRealName()}", "Veteran Kill");
                     return false;
                 }
                 if (killer.Is(CustomRoles.Pestilence))
                 {
                     target.SetRealKiller(killer);
-                    killer.RpcMurderPlayerV3(target);
+                    killer.RpcMurderPlayer(target);
                     Logger.Info($"{target.GetRealName()} 老兵反弹击杀：{target.GetRealName()}", "Pestilence Reflect");
                     return false;
                 }

--- a/Roles/Double/Mini.cs
+++ b/Roles/Double/Mini.cs
@@ -78,7 +78,7 @@ internal class Mini : RoleBase
         writer.Write(Age);
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         Age = reader.ReadInt32();
     }

--- a/Roles/Double/Mini.cs
+++ b/Roles/Double/Mini.cs
@@ -1,6 +1,7 @@
 using Hazel;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using TOHE.Roles.Core;
 using static TOHE.Translator;
 using static TOHE.Utils;
@@ -10,9 +11,9 @@ internal class Mini : RoleBase
 {
     //===========================SETUP================================\\
     private const int Id = 7000;
-    private static bool On = false;
-    public override bool IsEnable => On;
-    public static bool HasEnabled => CustomRoles.NiceMini.HasEnabled() || CustomRoles.EvilMini.HasEnabled();
+    private static readonly HashSet<byte> playerIdList = [];
+    public override bool IsEnable => HasEnabled;
+    public static bool HasEnabled => playerIdList.Any();
     public override CustomRoles ThisRoleBase => IsEvilMini ? CustomRoles.Impostor : CustomRoles.Crewmate;
     //==================================================================\\
 
@@ -25,7 +26,6 @@ internal class Mini : RoleBase
     private static OptionItem MinorCD;
     private static OptionItem MajorCD;
 
-    private static List<byte> playerIdList = [];
 
     public static int Age = new();
     private static bool IsEvilMini = false;
@@ -53,9 +53,8 @@ internal class Mini : RoleBase
     public override void Init()
     {
         GrowUpTime = 0;
-        playerIdList = [];
+        playerIdList.Clear();
         GrowUp = GrowUpDuration.GetInt() / 18;
-        On = false;
         Age = 0;
         misguessed = false;
 
@@ -65,7 +64,6 @@ internal class Mini : RoleBase
     public override void Add(byte playerId)
     {
         playerIdList.Add(playerId);
-        On = true;
 
         if (!AmongUsClient.Instance.AmHost) return;
         if (!Main.ResetCamPlayerList.Contains(playerId))

--- a/Roles/Impostor/Anonymous.cs
+++ b/Roles/Impostor/Anonymous.cs
@@ -59,7 +59,7 @@ internal class Anonymous : RoleBase
         writer.Write(HackLimit[playerId]);
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         byte PlayerId = reader.ReadByte();
         int Limit = reader.ReadInt32();

--- a/Roles/Impostor/Anonymous.cs
+++ b/Roles/Impostor/Anonymous.cs
@@ -1,6 +1,7 @@
 ﻿using AmongUs.GameOptions;
 using Hazel;
 using System.Collections.Generic;
+using System.Linq;
 using TOHE.Roles.Double;
 using UnityEngine;
 using static TOHE.Options;
@@ -10,19 +11,19 @@ namespace TOHE.Roles.Impostor;
 
 internal class Anonymous : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 5300;
-    private static List<byte> playerIdList = [];
-    
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> playerIdList = [];
+    public static bool HasEnabled => playerIdList.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Shapeshifter;
-
+    //==================================================================\\
     public override Sprite GetKillButtonSprite(PlayerControl player, bool shapeshifting) => CustomButton.Get("Hack");
 
     private static OptionItem HackLimitOpt;
     private static OptionItem KillCooldown;
 
-    private static Dictionary<byte, int> HackLimit = [];
+    private static readonly Dictionary<byte, int> HackLimit = [];
     private static List<byte> DeadBodyList = [];
 
     public static void SetupCustomOption()
@@ -35,16 +36,14 @@ internal class Anonymous : RoleBase
     }
     public override void Init()
     {
-        playerIdList = [];
-        HackLimit = [];
-        DeadBodyList = [];
-        On = false;
+        playerIdList.Clear();
+        HackLimit.Clear();
+        DeadBodyList.Clear();
     }
     public override void Add(byte playerId)
     {
         playerIdList.Add(playerId);
         HackLimit.TryAdd(playerId, HackLimitOpt.GetInt());
-        On = true;
     }
     public override void Remove(byte playerId)
     {

--- a/Roles/Impostor/AntiAdminer.cs
+++ b/Roles/Impostor/AntiAdminer.cs
@@ -5,6 +5,7 @@ using TOHE.Roles.Neutral;
 using UnityEngine;
 using static TOHE.Utils;
 using static TOHE.Translator;
+using System.Linq;
 
 namespace TOHE.Roles.Impostor;
 
@@ -12,12 +13,13 @@ namespace TOHE.Roles.Impostor;
 // 贡献：https://github.com/Yumenopai/TownOfHost_Y/tree/AntiAdminer
 internal class AntiAdminer : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 2800;
-    private static List<byte> playerIdList = [];
-
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly List<byte> playerIdList = [];
+    public static bool HasEnabled => playerIdList.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Impostor;
+    //==================================================================\\
 
     private static OptionItem CanCheckCamera;
     public static bool IsAdminWatch;
@@ -32,17 +34,15 @@ internal class AntiAdminer : RoleBase
     }
     public override void Init()
     {
-        playerIdList = [];
+        playerIdList.Clear();
         IsAdminWatch = false;
         IsVitalWatch = false;
         IsDoorLogWatch = false;
         IsCameraWatch = false;
-        On = false;
     }
     public override void Add(byte playerId)
     {
         playerIdList.Add(playerId);
-        On = true;
     }
     public override void Remove(byte playerId)
     {

--- a/Roles/Impostor/Arrogance.cs
+++ b/Roles/Impostor/Arrogance.cs
@@ -1,23 +1,26 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using static TOHE.Options;
 
 namespace TOHE.Roles.Impostor;
 
 internal class Arrogance : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 500;
-    public static List<byte> playerIdList = [];
-    public static bool On;
-    public override bool IsEnable => On;
+    public static HashSet<byte> playerIdList = [];
+    public static bool HasEnabled => playerIdList.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Impostor;
+    //==================================================================\\
 
     private static OptionItem DefaultKillCooldown;
     private static OptionItem ReduceKillCooldown;
     private static OptionItem MinKillCooldown;
     public static OptionItem BardChance;
 
-    private static Dictionary<byte, float> NowCooldown = [];
+    private static readonly Dictionary<byte, float> NowCooldown = [];
 
     public static void SetupCustomOption()
     {
@@ -34,15 +37,13 @@ internal class Arrogance : RoleBase
     }
     public override void Init()
     {
-        playerIdList = [];
-        NowCooldown = [];
-        On = false;
+        playerIdList.Clear();
+        NowCooldown.Clear();
     }
     public override void Add(byte playerId)
     {
         playerIdList.Add(playerId);
         NowCooldown.TryAdd(playerId, DefaultKillCooldown.GetFloat());
-        On = true;
     }
     public override void Remove(byte playerId)
     {

--- a/Roles/Impostor/Bard.cs
+++ b/Roles/Impostor/Bard.cs
@@ -1,18 +1,23 @@
-﻿namespace TOHE.Roles.Impostor;
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace TOHE.Roles.Impostor;
 
 internal class Bard: RoleBase
 {
-    public static bool On;
-    public override bool IsEnable => On;
+    //===========================SETUP================================\\
+    public static readonly HashSet<byte> PlayerIds = [];
+    public static bool HasEnabled => PlayerIds.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Impostor;
-
+    //==================================================================\\
     public override void Init()
     {
-        On = false;
+        PlayerIds.Clear();
     }
     public override void Add(byte playerId)
     {
-        On = true;
+        PlayerIds.Add(playerId);
     }
 
     public static bool CheckSpawn()

--- a/Roles/Impostor/Berserker.cs
+++ b/Roles/Impostor/Berserker.cs
@@ -112,7 +112,7 @@ internal class Berserker : RoleBase
             target.RpcTeleport(ExtendedPlayerControl.GetBlackRoomPosition());
             
             Main.PlayerStates[target.PlayerId].SetDead();
-            target.RpcMurderPlayerV3(target);
+            target.RpcMurderPlayer(target);
             target.SetRealKiller(killer);
 
             killer.SetKillCooldownV2();
@@ -136,7 +136,7 @@ internal class Berserker : RoleBase
                 {
                     Main.PlayerStates[player.PlayerId].deathReason = PlayerState.DeathReason.Bombed;
                     player.SetRealKiller(killer);
-                    player.RpcMurderPlayerV3(player);
+                    player.RpcMurderPlayer(player);
                 }
             }
         }

--- a/Roles/Impostor/Berserker.cs
+++ b/Roles/Impostor/Berserker.cs
@@ -1,16 +1,20 @@
 ﻿using UnityEngine;
 using System.Collections.Generic;
 using TOHE.Modules;
+using System.Linq;
 
 namespace TOHE.Roles.Impostor;
 
 internal class Berserker : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 600;
 
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> PlayerIds = [];
+    public static bool HasEnabled => PlayerIds.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Impostor;
+    //==================================================================\\
 
     private static OptionItem BerserkerKillCooldown;
     private static OptionItem BerserkerMax;
@@ -26,7 +30,7 @@ internal class Berserker : RoleBase
     private static OptionItem BerserkerFourCanNotKill;
     private static OptionItem BerserkerImmortalLevel;
 
-    private static Dictionary<byte, int> BerserkerKillMax = [];
+    private static readonly Dictionary<byte, int> BerserkerKillMax = [];
 
     public static void SetupCustomOption()
     {
@@ -55,13 +59,13 @@ internal class Berserker : RoleBase
     }
     public override void Init()
     {
-        BerserkerKillMax = [];
-        On = false;
+        BerserkerKillMax.Clear();
+        PlayerIds.Clear();
     }
     public override void Add(byte playerId)
     {
         BerserkerKillMax[playerId] = 0;
-        On = true;
+        PlayerIds.Add(playerId);
     }
     public override void Remove(byte playerId)
     {

--- a/Roles/Impostor/Blackmailer.cs
+++ b/Roles/Impostor/Blackmailer.cs
@@ -1,5 +1,6 @@
 ﻿using AmongUs.GameOptions;
 using System.Collections.Generic;
+using System.Linq;
 using TOHE.Roles.Core;
 using TOHE.Roles.Neutral;
 using static TOHE.MeetingHudStartPatch;
@@ -9,10 +10,13 @@ namespace TOHE.Roles.Impostor;
 
 internal class Blackmailer : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 24600;
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> PlayerIds = [];
+    public static bool HasEnabled => PlayerIds.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Shapeshifter;
+    //==================================================================\\
 
     private static OptionItem SkillCooldown;
 
@@ -27,11 +31,11 @@ internal class Blackmailer : RoleBase
     public override void Init()
     {
         ForBlackmailer = [];
-        On = false;
+        PlayerIds.Clear();
     }
     public override void Add(byte playerId)
     {
-        On = true;
+        PlayerIds.Add(playerId);
 
         if (AmongUsClient.Instance.AmHost)
         {
@@ -67,7 +71,7 @@ internal class Blackmailer : RoleBase
     }
 
     private static void ClearBlackmaile() => ForBlackmailer.Clear();
-    public static bool CheckBlackmaile(PlayerControl player) => On && ForBlackmailer.Contains(player.PlayerId);
+    public static bool CheckBlackmaile(PlayerControl player) => HasEnabled && ForBlackmailer.Contains(player.PlayerId);
 
     private string GetMarkOthers(PlayerControl seer, PlayerControl target = null, bool isForMeeting = false)
     {

--- a/Roles/Impostor/Bomber.cs
+++ b/Roles/Impostor/Bomber.cs
@@ -115,7 +115,7 @@ internal class Bomber : RoleBase
 
             Main.PlayerStates[tg.PlayerId].deathReason = PlayerState.DeathReason.Bombed;
             tg.SetRealKiller(shapeshifter);
-            tg.RpcMurderPlayerV3(tg);
+            tg.RpcMurderPlayer(tg);
         }
 
         var timer = shapeshiftIsHidden ? 0.3f : 1.5f;
@@ -127,7 +127,7 @@ internal class Bomber : RoleBase
                 if (totalAlive > 0 && !GameStates.IsEnded)
                 {
                     Main.PlayerStates[shapeshifter.PlayerId].deathReason = PlayerState.DeathReason.Bombed;
-                    shapeshifter.RpcMurderPlayerV3(shapeshifter);
+                    shapeshifter.RpcMurderPlayer(shapeshifter);
                 }
                 Utils.NotifyRoles();
             }, timer, $"{playerRole} was suicide");

--- a/Roles/Impostor/Bomber.cs
+++ b/Roles/Impostor/Bomber.cs
@@ -99,11 +99,11 @@ internal class Bomber : RoleBase
             var pos = shapeshifter.transform.position;
             var dis = Vector2.Distance(pos, tg.transform.position);
             
-            if (playerRole.Is(CustomRoles.Bomber))
+            if (playerRole is CustomRoles.Bomber)
             {
                 if (dis > BomberRadius.GetFloat()) continue;
             }
-            else if (playerRole.Is(CustomRoles.Nuker))
+            else if (playerRole is CustomRoles.Nuker)
             {
                 if (dis > NukeRadius.GetFloat()) continue;
             }
@@ -114,7 +114,7 @@ internal class Bomber : RoleBase
         }
 
         var timer = shapeshiftIsHidden ? 0.3f : 1.5f;
-        if (BomberDiesInExplosion.GetBool() && playerRole.Is(CustomRoles.Bomber))
+        if (BomberDiesInExplosion.GetBool() && playerRole is CustomRoles.Bomber)
         {
             _ = new LateTask(() =>
             {

--- a/Roles/Impostor/Bomber.cs
+++ b/Roles/Impostor/Bomber.cs
@@ -3,16 +3,21 @@ using TOHE.Modules;
 using TOHE.Roles.Crewmate;
 using TOHE.Roles.Neutral;
 using AmongUs.GameOptions;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace TOHE.Roles.Impostor;
 
 internal class Bomber : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 700;
 
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> Playerids = [];
+    public static bool HasEnabled => Playerids.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Shapeshifter;
+    //==================================================================\\
 
     public override Sprite GetAbilityButtonSprite(PlayerControl player, bool shapeshifting) => CustomButton.Get("Bomb");
 
@@ -56,11 +61,11 @@ internal class Bomber : RoleBase
     }
     public override void Init()
     {
-        On = false;
+        Playerids.Clear();
     }
     public override void Add(byte playerId)
     {
-        On = true;
+        Playerids.Add(playerId);
     }
     public static bool CheckSpawnNuker()
     {

--- a/Roles/Impostor/BountyHunter.cs
+++ b/Roles/Impostor/BountyHunter.cs
@@ -11,11 +11,13 @@ namespace TOHE.Roles.Impostor;
 
 internal class BountyHunter : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 800;
-    private static List<byte> playerIdList = [];
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> playerIdList = [];
+    public static bool HasEnabled => playerIdList.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Shapeshifter;
+    //==================================================================\\
 
     public override Sprite GetKillButtonSprite(PlayerControl player, bool shapeshifting) => CustomButton.Get("Handoff");
 
@@ -30,7 +32,7 @@ internal class BountyHunter : RoleBase
     private static bool ShowTargetArrow;
 
     private static Dictionary<byte, byte> Targets = [];
-    public static Dictionary<byte, float> ChangeTimer = [];
+    public static readonly Dictionary<byte, float> ChangeTimer = [];
 
     public static void SetupCustomOption()
     {
@@ -45,16 +47,14 @@ internal class BountyHunter : RoleBase
     }
     public override void Init()
     {
-        playerIdList = [];
-        On = false;
+        playerIdList.Clear();
 
-        Targets = [];
-        ChangeTimer = [];
+        Targets.Clear();
+        ChangeTimer.Clear();
     }
     public override void Add(byte playerId)
     {
         playerIdList.Add(playerId);
-        On = true;
 
         TargetChangeTime = OptionTargetChangeTime.GetFloat();
         SuccessKillCooldown = OptionSuccessKillCooldown.GetFloat();

--- a/Roles/Impostor/Butcher.cs
+++ b/Roles/Impostor/Butcher.cs
@@ -102,7 +102,7 @@ internal class Butcher : RoleBase
 
                 Vector2 location = new(ops.x + ((float)(rd.Next(1, 200) - 100) / 100), ops.y + ((float)(rd.Next(1, 200) - 100) / 100));
                 target.RpcTeleport(location);
-                target.RpcMurderPlayerV3(target);
+                target.RpcMurderPlayer(target);
                 MurderTargetLateTask[target.PlayerId] = (0, MurderTargetLateTask[target.PlayerId].Item2 + 1, ops);
             }
             else MurderTargetLateTask.Remove(target.PlayerId);

--- a/Roles/Impostor/Butcher.cs
+++ b/Roles/Impostor/Butcher.cs
@@ -9,10 +9,13 @@ namespace TOHE.Roles.Impostor;
 
 internal class Butcher : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 24300;
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> PlayerIds = [];
+    public static bool HasEnabled => PlayerIds.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Impostor;
+    //==================================================================\\
 
     private static Dictionary<byte, (int, int, Vector2)> MurderTargetLateTask = [];
     public static void SetupCustomOption()
@@ -22,11 +25,11 @@ internal class Butcher : RoleBase
     public override void Init()
     {
         MurderTargetLateTask = [];
-        On = false;
+        PlayerIds.Clear();
     }
     public override void Add(byte playerId)
     {
-        On = true;
+        PlayerIds.Add(playerId);
 
         if (AmongUsClient.Instance.AmHost)
         {

--- a/Roles/Impostor/Camouflager.cs
+++ b/Roles/Impostor/Camouflager.cs
@@ -1,5 +1,6 @@
 ﻿using AmongUs.GameOptions;
 using System.Collections.Generic;
+using System.Linq;
 using TOHE.Roles.AddOns.Common;
 using UnityEngine;
 using static TOHE.Translator;
@@ -8,11 +9,13 @@ namespace TOHE.Roles.Impostor;
 
 internal class Camouflager : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 2900;
-    public static bool On;
-    public override bool IsEnable => On;
+    public static readonly HashSet<byte> Playerids = [];
+    public static bool HasEnabled => Playerids.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Shapeshifter;
-
+    //==================================================================\\
     public override Sprite GetAbilityButtonSprite(PlayerControl player, bool shapeshifting) => CustomButton.Get("Camo");
 
     private static OptionItem CamouflageCooldownOpt;
@@ -44,9 +47,9 @@ internal class Camouflager : RoleBase
     }
     public override void Init()
     {
-        Timer = [];
+        Timer.Clear();
         AbilityActivated = false;
-        On = false;
+        Playerids.Clear();
     }
     public override void Add(byte playerId)
     {
@@ -56,7 +59,7 @@ internal class Camouflager : RoleBase
         DisableReportWhenCamouflageIsActive = DisableReportWhenCamouflageIsActiveOpt.GetBool();
         
         ShapeshiftIsHidden = Options.DisableShapeshiftAnimations.GetBool();
-        On = true;
+        Playerids.Add(playerId);
     }
     public override void ApplyGameOptions(IGameOptions opt, byte playerId)
     {

--- a/Roles/Impostor/Chronomancer.cs
+++ b/Roles/Impostor/Chronomancer.cs
@@ -1,15 +1,18 @@
 using System.Collections.Generic;
+using System.Linq;
 using static TOHE.Options;
 
 namespace TOHE.Roles.Impostor;
 
 internal class Chronomancer : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 900;
-    private static List<byte> playerIdList = [];
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> playerIdList = [];
+    public static bool HasEnabled => playerIdList.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Impostor;
+    //==================================================================\\
 
     private static Dictionary<byte, long> firstKill = [];
     private static Dictionary<byte, long> lastCooldownStart = [];
@@ -26,11 +29,10 @@ internal class Chronomancer : RoleBase
 
     public override void Init()
     {
-        playerIdList = [];
+        playerIdList.Clear();
         firstKill = [];
         lastCooldownStart = [];
         ChargedTime = [];
-        On = false;
     }
     public override void Add(byte playerId)
     {
@@ -39,7 +41,6 @@ internal class Chronomancer : RoleBase
         firstKill.Add(playerId, -1);
         ChargedTime.Add(playerId, 0);
         lastCooldownStart.Add(playerId, now);
-        On = true;
     }
 
     public override void SetKillCooldown(byte id) => OnSetKillCooldown(id);

--- a/Roles/Impostor/Cleaner.cs
+++ b/Roles/Impostor/Cleaner.cs
@@ -1,14 +1,18 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 namespace TOHE.Roles.Impostor;
 
 internal class Cleaner : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 3000;
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> Playerids = [];
+    public static bool HasEnabled => Playerids.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Impostor;
+    //==================================================================\\
 
     public override Sprite ReportButtonSprite => CustomButton.Get("Clean");
 
@@ -30,11 +34,11 @@ internal class Cleaner : RoleBase
     public override void Init()
     {
         CleanerBodies = [];
-        On = false;
+        Playerids.Clear();
     }
     public override void Add(byte playerId)
     {
-        On = true;
+        Playerids.Add(playerId);
     }
 
     public override void SetKillCooldown(byte id) => Main.AllPlayerKillCooldown[id] = KillCooldown.GetFloat();

--- a/Roles/Impostor/Consigliere.cs
+++ b/Roles/Impostor/Consigliere.cs
@@ -1,6 +1,7 @@
 using HarmonyLib;
 using Hazel;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using static TOHE.Options;
 
@@ -8,16 +9,19 @@ namespace TOHE.Roles.Impostor;
 
 internal class Consigliere : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 3100;
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> PlayerIds = [];
+    public static bool HasEnabled => PlayerIds.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Impostor;
+    //==================================================================\\
 
     private static OptionItem KillCooldown;
     private static OptionItem DivinationMaxCount;
 
-    private static Dictionary<byte, int> DivinationCount = [];
-    private static Dictionary<byte, List<byte>> DivinationTarget = [];
+    private static readonly Dictionary<byte, int> DivinationCount = [];
+    private static readonly Dictionary<byte, List<byte>> DivinationTarget = [];
 
     public static void SetupCustomOption()
     {
@@ -29,15 +33,15 @@ internal class Consigliere : RoleBase
     }
     public override void Init()
     {
-        DivinationCount = [];
-        DivinationTarget = [];
-        On = false;
+        DivinationCount.Clear();
+        DivinationTarget.Clear();
+        PlayerIds.Clear();
     }
     public override void Add(byte playerId)
     {
         DivinationCount.TryAdd(playerId, DivinationMaxCount.GetInt());
         DivinationTarget.TryAdd(playerId, []);
-        On = true;
+        PlayerIds.Add(playerId);
 
         var pc = Utils.GetPlayerById(playerId);
         pc.AddDoubleTrigger();

--- a/Roles/Impostor/Convict.cs
+++ b/Roles/Impostor/Convict.cs
@@ -7,6 +7,7 @@ internal class Convict : RoleBase // Loonie ass role 💀💀💀
     public override bool IsEnable => On;
 
     public override CustomRoles ThisRoleBase => CustomRoles.Crewmate;
+    public override bool HasTasks(GameData.PlayerInfo player, CustomRoles role, bool ForRecompute) => !ForRecompute;
 
     public override void Init()
     {

--- a/Roles/Impostor/Convict.cs
+++ b/Roles/Impostor/Convict.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace TOHE.Roles.Impostor;
 
-internal class Convict : RoleBase
+internal class Convict : RoleBase // Loonie ass role 💀💀💀
 {
     public static bool On;
     public override bool IsEnable => On;

--- a/Roles/Impostor/Councillor.cs
+++ b/Roles/Impostor/Councillor.cs
@@ -2,6 +2,7 @@
 using Hazel;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 using TOHE.Modules.ChatManager;
 using TOHE.Roles.Crewmate;
@@ -13,9 +14,13 @@ namespace TOHE.Roles.Impostor;
 
 internal class Councillor : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 1000;
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> PlayerIds = [];
+    public static bool HasEnabled => PlayerIds.Any();
+    public override bool IsEnable => HasEnabled;
+    public override CustomRoles ThisRoleBase => CustomRoles.Impostor;
+    //==================================================================\\
 
     private static OptionItem MurderLimitPerMeeting;
     private static OptionItem TryHideMsg;
@@ -25,7 +30,6 @@ internal class Councillor : RoleBase
     
     private static Dictionary<byte, int> MurderLimit = [];
 
-    public override CustomRoles ThisRoleBase => CustomRoles.Impostor;
 
     public static void SetupCustomOption()
     {
@@ -42,12 +46,12 @@ internal class Councillor : RoleBase
     public override void Init()
     {
         MurderLimit = [];
-        On = false;
+        PlayerIds.Clear();
     }
     public override void Add(byte playerId)
     {
         MurderLimit.Add(playerId, MurderLimitPerMeeting.GetInt());
-        On = true;
+        PlayerIds.Add(playerId);
     }
     public override void AfterMeetingTasks()
     {

--- a/Roles/Impostor/Crewpostor.cs
+++ b/Roles/Impostor/Crewpostor.cs
@@ -136,7 +136,7 @@ internal class Crewpostor : RoleBase
                 else
                 {
                     target.SetRealKiller(player);
-                    player.RpcMurderPlayerV3(target);
+                    player.RpcMurderPlayer(target);
                     player.RpcGuardAndKill();
                     Logger.Info("lunge mode kill", "Crewpostor");
                 }
@@ -145,7 +145,7 @@ internal class Crewpostor : RoleBase
             else
             {
                 player.SetRealKiller(target);
-                target.RpcMurderPlayerV3(player);
+                target.RpcMurderPlayer(player);
                 player.RpcGuardAndKill();
                 Logger.Info($"Crewpostor tried to kill pestilence (reflected back)：{target.GetNameWithRole().RemoveHtmlTags()} => {player.GetNameWithRole().RemoveHtmlTags()}", "Pestilence Reflect");
             }

--- a/Roles/Impostor/Crewpostor.cs
+++ b/Roles/Impostor/Crewpostor.cs
@@ -9,10 +9,13 @@ namespace TOHE.Roles.Impostor;
 
 internal class Crewpostor : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 5800;
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> PlayerIds = [];
+    public static bool HasEnabled => PlayerIds.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Engineer;
+    //==================================================================\\
 
     private static OptionItem CanKillAllies;
     private static OptionItem KnowsAllies;
@@ -41,12 +44,12 @@ internal class Crewpostor : RoleBase
     public override void Init()
     {
         TasksDone = [];
-        On = false;
+        PlayerIds.Clear();
     }
     public override void Add(byte playerId)
     {
         TasksDone[playerId] = 0;
-        On = true;
+        PlayerIds.Add(playerId);
     }
 
     private static void SendRPC(byte cpID, int tasksDone)

--- a/Roles/Impostor/Crewpostor.cs
+++ b/Roles/Impostor/Crewpostor.cs
@@ -51,6 +51,16 @@ internal class Crewpostor : RoleBase
         TasksDone[playerId] = 0;
         PlayerIds.Add(playerId);
     }
+    public override bool HasTasks(GameData.PlayerInfo player, CustomRoles role, bool ForRecompute) 
+    { 
+        if (ForRecompute & !player.IsDead)
+            return false;
+        if (player.IsDead)
+            return false;
+
+        return true;
+    
+    }
 
     private static void SendRPC(byte cpID, int tasksDone)
     {

--- a/Roles/Impostor/CursedWolf.cs
+++ b/Roles/Impostor/CursedWolf.cs
@@ -68,7 +68,7 @@ internal class CursedWolf : RoleBase
         SpellCount[target.PlayerId] -= 1;
         SendRPC(target.PlayerId);
 
-        if (KillAttacker.GetBool())
+        if (KillAttacker.GetBool() && target.RpcCheckAndMurder(killer, true))
         {
             killer.SetRealKiller(target);
             Logger.Info($"{target.GetNameWithRole()} Spell Count: {SpellCount[target.PlayerId]}", "Cursed Wolf");

--- a/Roles/Impostor/CursedWolf.cs
+++ b/Roles/Impostor/CursedWolf.cs
@@ -73,7 +73,7 @@ internal class CursedWolf : RoleBase
             killer.SetRealKiller(target);
             Logger.Info($"{target.GetNameWithRole()} Spell Count: {SpellCount[target.PlayerId]}", "Cursed Wolf");
             Main.PlayerStates[killer.PlayerId].deathReason = PlayerState.DeathReason.Curse;
-            killer.RpcMurderPlayerV3(killer);
+            killer.RpcMurderPlayer(killer);
         }
         return false;
     }

--- a/Roles/Impostor/Dazzler.cs
+++ b/Roles/Impostor/Dazzler.cs
@@ -11,10 +11,13 @@ namespace TOHE.Roles.Impostor;
 
 internal class Dazzler : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 5400;
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> PlayerIds = [];
+    public static bool HasEnabled => PlayerIds.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Shapeshifter;
+    //==================================================================\\
 
     private static OptionItem KillCooldown;
     private static OptionItem ShapeshiftCooldown;
@@ -41,13 +44,13 @@ internal class Dazzler : RoleBase
     public override void Init()
     {
         PlayersDazzled = [];
-        On = false;
+        PlayerIds.Clear();
     }
 
     public override void Add(byte playerId)
     {
         PlayersDazzled.TryAdd(playerId, []);
-        On = true;
+        PlayerIds.Add(playerId);
     }
 
     public override void ApplyGameOptions(IGameOptions opt, byte playerId)

--- a/Roles/Impostor/Deathpact.cs
+++ b/Roles/Impostor/Deathpact.cs
@@ -202,7 +202,7 @@ internal class Deathpact : RoleBase
         
         Main.PlayerStates[target.PlayerId].deathReason = PlayerState.DeathReason.Suicide;
         target.SetRealKiller(deathpact);
-        target.RpcMurderPlayerV3(target);
+        target.RpcMurderPlayer(target);
     }
 
     public override string GetMark(PlayerControl seer, PlayerControl seen = null, bool isForMeeting = false)

--- a/Roles/Impostor/Deathpact.cs
+++ b/Roles/Impostor/Deathpact.cs
@@ -14,10 +14,13 @@ namespace TOHE.Roles.Impostor;
 
 internal class Deathpact : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 1200;
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> Playerids = [];
+    public static bool HasEnabled => Playerids.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Shapeshifter;
+    //==================================================================\\
 
     private static OptionItem KillCooldown;
     private static OptionItem ShapeshiftCooldown;
@@ -29,9 +32,9 @@ internal class Deathpact : RoleBase
     private static OptionItem KillDeathpactPlayersOnMeeting;
     private static OptionItem PlayersInDeathpactCanCallMeeting;
 
-    private static List<byte> ActiveDeathpacts = [];
-    private static Dictionary<byte, List<PlayerControl>> PlayersInDeathpact = [];
-    private static Dictionary<byte, long> DeathpactTime = [];
+    private static readonly List<byte> ActiveDeathpacts = [];
+    private static readonly Dictionary<byte, List<PlayerControl>> PlayersInDeathpact = [];
+    private static readonly Dictionary<byte, long> DeathpactTime = [];
 
     public static void SetupCustomOption()
     {
@@ -54,16 +57,16 @@ internal class Deathpact : RoleBase
 
     public override void Init()
     {
-        PlayersInDeathpact = [];
-        DeathpactTime = [];
-        ActiveDeathpacts = [];
-        On = false;
+        PlayersInDeathpact.Clear();
+        DeathpactTime.Clear();
+        ActiveDeathpacts.Clear();
+        Playerids.Clear();
     }
     public override void Add(byte playerId)
     {
         PlayersInDeathpact.TryAdd(playerId, []);
         DeathpactTime.TryAdd(playerId, 0);
-        On = true;
+        Playerids.Add(playerId);
     }
 
     public override void ApplyGameOptions(IGameOptions opt, byte playerId)

--- a/Roles/Impostor/Devourer.cs
+++ b/Roles/Impostor/Devourer.cs
@@ -10,12 +10,15 @@ namespace TOHE.Roles.Impostor;
 internal class Devourer : RoleBase
 {
     private readonly static GameData.PlayerOutfit ConsumedOutfit = new GameData.PlayerOutfit().Set("", 15, "", "", "visor_Crack", "", "");
-    private static Dictionary<byte, GameData.PlayerOutfit> OriginalPlayerSkins = [];
+    private static readonly Dictionary<byte, GameData.PlayerOutfit> OriginalPlayerSkins = [];
 
+    //===========================SETUP================================\\
     private const int Id = 5500;
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> PlayerIds = [];
+    public static bool HasEnabled => PlayerIds.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Shapeshifter;
+    //==================================================================\\
 
     private static OptionItem DefaultKillCooldown;
     private static OptionItem ReduceKillCooldown;
@@ -23,8 +26,8 @@ internal class Devourer : RoleBase
     private static OptionItem ShapeshiftCooldown;
     private static OptionItem HideNameOfConsumedPlayer;
 
-    private static Dictionary<byte, float> NowCooldown = [];
-    private static Dictionary<byte, List<byte>> PlayerSkinsCosumed = [];
+    private static readonly Dictionary<byte, float> NowCooldown = [];
+    private static readonly Dictionary<byte, List<byte>> PlayerSkinsCosumed = [];
 
     public static void SetupCustomOption()
     {
@@ -41,16 +44,16 @@ internal class Devourer : RoleBase
     }
     public override void Init()
     {
-        PlayerSkinsCosumed = [];
-        OriginalPlayerSkins = [];
-        NowCooldown = [];
-        On = false;
+        PlayerSkinsCosumed.Clear();
+        OriginalPlayerSkins.Clear();
+        NowCooldown.Clear();
+        PlayerIds.Clear();
     }
     public override void Add(byte playerId)
     {
         PlayerSkinsCosumed.TryAdd(playerId, []);
         NowCooldown.TryAdd(playerId, DefaultKillCooldown.GetFloat());
-        On = true;
+        PlayerIds.Add(playerId);
     }
 
     public override void ApplyGameOptions(IGameOptions opt, byte playerId)

--- a/Roles/Impostor/Disperser.cs
+++ b/Roles/Impostor/Disperser.cs
@@ -1,5 +1,7 @@
 ﻿using AmongUs.GameOptions;
+using Il2CppSystem.Collections.Generic;
 using TOHE.Modules;
+using System.Linq;
 using static TOHE.Options;
 using static TOHE.Translator;
 using static TOHE.Utils;
@@ -8,10 +10,13 @@ namespace TOHE.Roles.Impostor;
 
 internal class Disperser : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 24400;
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> PlayerIds = new();
+    public static bool HasEnabled => PlayerIds.Count > 0;
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Shapeshifter;
+    //==================================================================\\
 
     private static OptionItem DisperserShapeshiftCooldown;
     private static OptionItem DisperserShapeshiftDuration;
@@ -27,11 +32,11 @@ internal class Disperser : RoleBase
 
     public override void Init()
     {
-        On = false;
+        PlayerIds.Clear();
     }
     public override void Add(byte playerId)
     {
-        On = true;
+        PlayerIds.Add(playerId);
     }
 
     public override void ApplyGameOptions(IGameOptions opt, byte playerId)

--- a/Roles/Impostor/Eraser.cs
+++ b/Roles/Impostor/Eraser.cs
@@ -56,7 +56,7 @@ internal class Eraser : RoleBase
         writer.Write(EraseLimit[playerId]);
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         byte playerId = reader.ReadByte();
         int limit = reader.ReadInt32();

--- a/Roles/Impostor/Escapist.cs
+++ b/Roles/Impostor/Escapist.cs
@@ -1,5 +1,6 @@
 ﻿using AmongUs.GameOptions;
 using System.Collections.Generic;
+using System.Linq;
 using TOHE.Modules;
 using UnityEngine;
 
@@ -7,18 +8,20 @@ namespace TOHE.Roles.Impostor;
 
 internal class Escapist : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 4000;
 
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> PlayerIds = [];
+    public static bool HasEnabled => PlayerIds.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Shapeshifter;
-
+    //==================================================================\\
     public override Sprite GetAbilityButtonSprite(PlayerControl player, bool shapeshifting) => CustomButton.Get("abscond");
 
     private static OptionItem ShapeshiftDuration;
     private static OptionItem ShapeshiftCooldown;
 
-    private static Dictionary<byte, Vector2> EscapeLocation = [];
+    private static readonly Dictionary<byte, Vector2> EscapeLocation = [];
 
     public static void SetupCustomOption()
     {
@@ -32,12 +35,12 @@ internal class Escapist : RoleBase
     }
     public override void Init()
     {
-        EscapeLocation = [];
-        On = false;
+        EscapeLocation.Clear();
+        PlayerIds.Clear();
     }
     public override void Add(byte playerId)
     {
-        On = true;
+        PlayerIds.Add(playerId);
     }
 
     public override void ApplyGameOptions(IGameOptions opt, byte playerId)

--- a/Roles/Impostor/EvilGuesser.cs
+++ b/Roles/Impostor/EvilGuesser.cs
@@ -1,14 +1,19 @@
-﻿using UnityEngine;
+﻿using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
 
 namespace TOHE.Roles.Impostor;
 
 internal class EvilGuesser : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 1300;
 
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> PlayerIds = [];
+    public static bool HasEnabled => PlayerIds.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Impostor;
+    //==================================================================\\
 
     private static OptionItem EGCanGuessTime;
     private static OptionItem EGCanGuessImp;
@@ -34,11 +39,11 @@ internal class EvilGuesser : RoleBase
     }
     public override void Init()
     {
-        On = false;
+        PlayerIds.Clear();
     }
     public override void Add(byte playerId)
     {
-        On = true;
+        PlayerIds.Add(playerId);
     }
 
     public override string PVANameText(PlayerVoteArea pva, PlayerControl seer, PlayerControl target)

--- a/Roles/Impostor/EvilTracker.cs
+++ b/Roles/Impostor/EvilTracker.cs
@@ -2,6 +2,7 @@ using AmongUs.GameOptions;
 using Hazel;
 using Il2CppSystem.Text;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using static TOHE.Options;
 using static TOHE.Translator;
@@ -10,13 +11,13 @@ namespace TOHE.Roles.Impostor;
 
 internal class EvilTracker : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 1400;
     private static readonly HashSet<byte> playerIdList = [];
-    
-    public static bool On;
-    public override bool IsEnable => On;
+    public static bool HasEnabled => playerIdList.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => (TargetMode)OptionTargetMode.GetValue() == TargetMode.Never ? CustomRoles.Impostor : CustomRoles.Shapeshifter;
-
+    //==================================================================\\
     public override Sprite GetAbilityButtonSprite(PlayerControl player, bool shapeshifting) => CustomButton.Get("Track");
 
     private static OptionItem OptionCanSeeKillFlash;
@@ -62,7 +63,6 @@ internal class EvilTracker : RoleBase
         Target.Clear();
         CanSetTarget.Clear();
         ImpostorsId.Clear();
-        On = false;
 
         CanSeeKillFlash = OptionCanSeeKillFlash.GetBool();
         CurrentTargetMode = (TargetMode)OptionTargetMode.GetValue();
@@ -75,7 +75,6 @@ internal class EvilTracker : RoleBase
         CanSetTarget.Add(playerId, CurrentTargetMode != TargetMode.Never);
 
         ImpostorsId[playerId] = [];
-        On = true;
 
         foreach (var target in Main.AllAlivePlayerControls)
         {

--- a/Roles/Impostor/Fireworker.cs
+++ b/Roles/Impostor/Fireworker.cs
@@ -150,7 +150,7 @@ internal class Fireworker : RoleBase
                         {
                             Main.PlayerStates[player.PlayerId].deathReason = PlayerState.DeathReason.Bombed;
                             player.SetRealKiller(shapeshifter);
-                            player.RpcMurderPlayerV3(player);
+                            player.RpcMurderPlayer(player);
                         }
                     }
                 }
@@ -160,7 +160,7 @@ internal class Fireworker : RoleBase
                     if (totalAlive != 1)
                     {
                         Main.PlayerStates[shapeshifterId].deathReason = PlayerState.DeathReason.Misfire;
-                        shapeshifter.RpcMurderPlayerV3(shapeshifter);
+                        shapeshifter.RpcMurderPlayer(shapeshifter);
                     }
                     shapeshifter.MarkDirtySettings();
                 }

--- a/Roles/Impostor/Fireworker.cs
+++ b/Roles/Impostor/Fireworker.cs
@@ -1,6 +1,7 @@
 using AmongUs.GameOptions;
 using Hazel;
 using System.Collections.Generic;
+using System.Linq;
 using TOHE.Roles.Neutral;
 using UnityEngine;
 using static TOHE.Translator;
@@ -18,23 +19,23 @@ internal class Fireworker : RoleBase
         FireEnd = 16,
         CanUseKill = Initial | FireEnd
     }
-
+    //===========================SETUP================================\\
     private const int Id = 3200;
-    public static bool On;
-    public override bool IsEnable => On;
-
+    private static readonly HashSet<byte> PlayerIds = [];
+    public static bool HasEnabled => PlayerIds.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Shapeshifter;
-
+    //==================================================================\\
     public override Sprite GetAbilityButtonSprite(PlayerControl player, bool shapeshifting) => nowFireworkerCount[player.PlayerId] == 0 ? CustomButton.Get("FireworkD") : CustomButton.Get("FireworkP");
 
     private static OptionItem FireworkerCount;
     private static OptionItem FireworkerRadius;
     private static OptionItem CanKill;
 
-    private static Dictionary<byte, int> nowFireworkerCount = [];
-    private static Dictionary<byte, List<Vector3>> FireworkerPosition = [];
-    private static Dictionary<byte, FireworkerState> state = [];
-    private static Dictionary<byte, int> FireworkerBombKill = [];
+    private static readonly Dictionary<byte, int> nowFireworkerCount = [];
+    private static readonly Dictionary<byte, List<Vector3>> FireworkerPosition = [];
+    private static readonly Dictionary<byte, FireworkerState> state = [];
+    private static readonly Dictionary<byte, int> FireworkerBombKill = [];
     private static int fireworkerCount = 1;
     private static float fireworkerRadius = 1;
 
@@ -50,11 +51,11 @@ internal class Fireworker : RoleBase
 
     public override void Init()
     {
-        On = false;
-        nowFireworkerCount = [];
-        FireworkerPosition = [];
-        state = [];
-        FireworkerBombKill = [];
+        PlayerIds.Clear();
+        nowFireworkerCount.Clear();
+        FireworkerPosition.Clear();
+        state.Clear();
+        FireworkerBombKill.Clear();
 
         fireworkerCount = FireworkerCount.GetInt();
         fireworkerRadius = FireworkerRadius.GetFloat();
@@ -66,7 +67,7 @@ internal class Fireworker : RoleBase
         FireworkerPosition[playerId] = [];
         state.TryAdd(playerId, FireworkerState.Initial);
         FireworkerBombKill[playerId] = 0;
-        On = true;
+        PlayerIds.Add(playerId);
     }
 
     private static void SendRPC(byte playerId)

--- a/Roles/Impostor/Gangster.cs
+++ b/Roles/Impostor/Gangster.cs
@@ -7,17 +7,19 @@ using TOHE.Roles.Double;
 using TOHE.Roles.Neutral;
 using UnityEngine;
 using static TOHE.Translator;
+using System.Linq;
 
 namespace TOHE.Roles.Impostor;
 
 internal class Gangster : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 3300;
-    private static List<byte> playerIdList = [];
-
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> playerIdList = [];
+    public static bool HasEnabled => playerIdList.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Impostor;
+    //==================================================================\\
 
     public override Sprite GetKillButtonSprite(PlayerControl player, bool shapeshifting) => CanRecruit(player.PlayerId) ? CustomButton.Get("Sidekick") : null;
 
@@ -31,7 +33,7 @@ internal class Gangster : RoleBase
     public static OptionItem MarshallCanBeMadmate;
     public static OptionItem OverseerCanBeMadmate;
 
-    private static Dictionary<byte, int> RecruitLimit = [];
+    private static readonly Dictionary<byte, int> RecruitLimit = [];
 
     public static void SetupCustomOption()
     {
@@ -51,15 +53,13 @@ internal class Gangster : RoleBase
     }
     public override void Init()
     {
-        playerIdList = [];
-        RecruitLimit = [];
-        On = false;
+        playerIdList.Clear();
+        RecruitLimit.Clear();
     }
     public override void Add(byte playerId)
     {
         playerIdList.Add(playerId);
         RecruitLimit.TryAdd(playerId, RecruitLimitOpt.GetInt());
-        On = true;
     }
     private static void SendRPC(byte playerId)
     {

--- a/Roles/Impostor/Gangster.cs
+++ b/Roles/Impostor/Gangster.cs
@@ -69,7 +69,7 @@ internal class Gangster : RoleBase
         writer.Write(RecruitLimit[playerId]);
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         byte PlayerId = reader.ReadByte();
         int Limit = reader.ReadInt32();

--- a/Roles/Impostor/Godfather.cs
+++ b/Roles/Impostor/Godfather.cs
@@ -1,18 +1,22 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using TOHE.Roles.Core;
 
 namespace TOHE.Roles.Impostor;
 
 internal class Godfather : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 3400;
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> PlayerIds = [];
+    public static bool HasEnabled => PlayerIds.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Impostor;
+    //==================================================================\\
 
     private static OptionItem GodfatherChangeOpt;
 
-    private static List<byte> GodfatherTarget = [];
+    private static readonly List<byte> GodfatherTarget = [];
 
     private enum GodfatherChangeMode
     {
@@ -29,12 +33,12 @@ internal class Godfather : RoleBase
 
     public override void Init()
     {
-        On = false;
-        GodfatherTarget = [];
+        PlayerIds.Clear();
+        GodfatherTarget.Clear();
     }
     public override void Add(byte playerId)
     {
-        On = true;
+        PlayerIds.Add(playerId);
 
         if (AmongUsClient.Instance.AmHost)
         {

--- a/Roles/Impostor/Greedy.cs
+++ b/Roles/Impostor/Greedy.cs
@@ -1,21 +1,24 @@
 ﻿using Hazel;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace TOHE;
 
 // Thanks： https://github.com/Yumenopai/TownOfHost_Y
 internal class Greedy : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 1500;
-    public static List<byte> playerIdList = [];
-    public static bool On;
-    public override bool IsEnable => On;
+    public static HashSet<byte> playerIdList = [];
+    public static bool HasEnabled => playerIdList.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Impostor;
+    //==================================================================\\
 
     private static OptionItem OddKillCooldown;
     private static OptionItem EvenKillCooldown;
 
-    private static Dictionary<byte, bool> IsOdd = [];
+    private static readonly Dictionary<byte, bool> IsOdd = [];
 
     public static void SetupCustomOption()
     {
@@ -29,15 +32,13 @@ internal class Greedy : RoleBase
     }
     public override void Init()
     {
-        On = false;
-        playerIdList = [];
-        IsOdd = [];
+        playerIdList.Clear();
+        IsOdd.Clear();
     }
     public override void Add(byte playerId)
     {
         playerIdList.Add(playerId);
         IsOdd.Add(playerId, true);
-        On = true;
     }
 
     private static void SendRPC(byte playerId)

--- a/Roles/Impostor/Hangman.cs
+++ b/Roles/Impostor/Hangman.cs
@@ -1,4 +1,6 @@
 ﻿using AmongUs.GameOptions;
+using System.Collections.Generic;
+using System.Linq;
 using TOHE.Roles.AddOns.Impostor;
 using UnityEngine;
 using static TOHE.Options;
@@ -6,10 +8,14 @@ namespace TOHE.Roles.Impostor;
 
 internal class Hangman : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 24500;
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> PlayerIds = [];
+    public static bool HasEnabled => PlayerIds.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Shapeshifter;
+
+    //==================================================================\\
 
     private static OptionItem ShapeshiftCooldown;
     private static OptionItem ShapeshiftDuration;
@@ -24,11 +30,11 @@ internal class Hangman : RoleBase
     }
     public override void Init()
     {
-        On = false;
+        PlayerIds.Clear();
     }
     public override void Add(byte playerId)
     {
-        On = true;
+        PlayerIds.Add(playerId);
     }
 
     public override void ApplyGameOptions(IGameOptions opt, byte playerId)

--- a/Roles/Impostor/Inhibitor.cs
+++ b/Roles/Impostor/Inhibitor.cs
@@ -1,12 +1,18 @@
 ﻿
+using System.Collections.Generic;
+using System.Linq;
+
 namespace TOHE.Roles.Impostor;
 
 internal class Inhibitor : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 1600;
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> PlayerIds = [];
+    public static bool HasEnabled => PlayerIds.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Impostor;
+    //==================================================================\\
 
     private static OptionItem InhibitorCD;
 
@@ -19,11 +25,11 @@ internal class Inhibitor : RoleBase
     }
     public override void Init()
     {
-        On = false;
+        PlayerIds.Clear();
     }
     public override void Add(byte playerId)
     {
-        On = true;
+        PlayerIds.Add(playerId);
     }
 
     public override void SetKillCooldown(byte id) => Main.AllPlayerKillCooldown[id] = InhibitorCD.GetFloat();

--- a/Roles/Impostor/Instigator.cs
+++ b/Roles/Impostor/Instigator.cs
@@ -6,11 +6,13 @@ namespace TOHE.Roles.Impostor;
 
 internal class Instigator : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 1700;
-
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> playerIdList = [];
+    public static bool HasEnabled => playerIdList.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Impostor;
+    //==================================================================\\
 
     private static OptionItem KillCooldown;
     private static OptionItem AbilityLimit;
@@ -18,7 +20,6 @@ internal class Instigator : RoleBase
 
     private static readonly IRandom rd = IRandom.Instance;
 
-    private static List<byte> playerIdList = [];
     private static Dictionary<int, int> AbilityUseCount = [];
 
     public static void SetupCustomOption()
@@ -33,15 +34,13 @@ internal class Instigator : RoleBase
     }
     public override void Init()
     {
-        On = false;
-        playerIdList = [];
+        playerIdList.Clear();
         AbilityUseCount = [];
     }
     public override void Add(byte playerId)
     {
         playerIdList.Add(playerId);
         AbilityUseCount.Add(playerId, 0);
-        On = true;
     }
 
     public override void SetKillCooldown(byte id) => Main.AllPlayerKillCooldown[id] = KillCooldown.GetFloat();

--- a/Roles/Impostor/Kamikaze.cs
+++ b/Roles/Impostor/Kamikaze.cs
@@ -1,5 +1,6 @@
 using Hazel;
 using System.Collections.Generic;
+using System.Linq;
 using TOHE.Roles.Core;
 using TOHE.Roles.Double;
 using UnityEngine;
@@ -10,17 +11,20 @@ namespace TOHE.Roles.Impostor;
 
 internal class Kamikaze : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 26900;
 
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> Playerids = [];
+    public static bool HasEnabled => Playerids.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Impostor;
+    //==================================================================\\
 
     private static OptionItem KillCooldown;
     private static OptionItem OptMaxMarked;
 
-    private static Dictionary<byte, byte> KamikazedList = [];
-    private static Dictionary<byte, int> MarkedLim = [];
+    private static readonly Dictionary<byte, byte> KamikazedList = [];
+    private static readonly Dictionary<byte, int> MarkedLim = [];
 
     public static void SetupCustomOption()
     {
@@ -33,9 +37,8 @@ internal class Kamikaze : RoleBase
     }
     public override void Init()
     {
-        On = false;
-        MarkedLim = [];
-        KamikazedList = [];
+        MarkedLim.Clear();
+        KamikazedList.Clear();
     }
     public override void Add(byte playerId)
     {
@@ -45,7 +48,7 @@ internal class Kamikaze : RoleBase
         var pc = Utils.GetPlayerById(playerId);
         pc.AddDoubleTrigger();
 
-        On = true;
+        Playerids.Add(playerId);
 
         if (AmongUsClient.Instance.AmHost)
         {

--- a/Roles/Impostor/Kamikaze.cs
+++ b/Roles/Impostor/Kamikaze.cs
@@ -107,7 +107,7 @@ internal class Kamikaze : RoleBase
             } 
             else
             {
-                killer.RpcMurderPlayerV3(target);
+                killer.RpcMurderPlayer(target);
             }
         });
         
@@ -131,7 +131,7 @@ internal class Kamikaze : RoleBase
             {
                 Main.PlayerStates[kamikameha.PlayerId].deathReason = PlayerState.DeathReason.Targeted;
                 kamikameha.SetRealKiller(kami);
-                kamikameha.RpcMurderPlayerV3(kamikameha);
+                kamikameha.RpcMurderPlayer(kamikameha);
                 // Logger.Info($"{alivePlayer.GetNameWithRole()} is the killer of {kamikameha.GetNameWithRole()}", "Kamikaze"); -- Works fine
             }
 

--- a/Roles/Impostor/KillingMachine.cs
+++ b/Roles/Impostor/KillingMachine.cs
@@ -46,7 +46,7 @@ internal class KillingMachine : RoleBase
 
     public override bool ForcedCheckMurderAsKiller(PlayerControl killer, PlayerControl target)
     {
-        killer.RpcMurderPlayerV3(target);
+        killer.RpcMurderPlayer(target);
         killer.ResetKillCooldown();
         return false;
     }

--- a/Roles/Impostor/KillingMachine.cs
+++ b/Roles/Impostor/KillingMachine.cs
@@ -1,15 +1,20 @@
 ﻿using AmongUs.GameOptions;
+using System.Collections.Generic;
+using System.Linq;
 using static TOHE.Options;
 
 namespace TOHE.Roles.Impostor;
 
 internal class KillingMachine : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 23800;
 
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> PlayerIds = [];
+    public static bool HasEnabled => PlayerIds.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Impostor;
+    //==================================================================\\
 
     private static OptionItem MNKillCooldown;
 
@@ -23,11 +28,11 @@ internal class KillingMachine : RoleBase
 
     public override void Init()
     {
-        On = false;
+        PlayerIds.Clear();
     }
     public override void Add(byte playerId)
     {
-        On = true;
+        PlayerIds.Add(playerId);
     }
 
     public override bool CanUseImpostorVentButton(PlayerControl pc) => false;

--- a/Roles/Impostor/Lightning.cs
+++ b/Roles/Impostor/Lightning.cs
@@ -147,7 +147,7 @@ internal class Lightning : RoleBase
                 deList.Add(gs.PlayerId);
                 Main.PlayerStates[gs.PlayerId].deathReason = PlayerState.DeathReason.Quantization;
                 gs.SetRealKiller(RealKiller[gs.PlayerId]);
-                gs.RpcMurderPlayerV3(gs);
+                gs.RpcMurderPlayer(gs);
 
                 Logger.Info($"{gs.GetNameWithRole()} As a quantum ghost dying from a collision", "Lightning");
                 break;

--- a/Roles/Impostor/Lightning.cs
+++ b/Roles/Impostor/Lightning.cs
@@ -11,19 +11,20 @@ namespace TOHE.Roles.Impostor;
 
 internal class Lightning : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 24100;
-
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> playerIdList = [];
+    public static bool HasEnabled => playerIdList.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Impostor;
+    //==================================================================\\
 
     private static OptionItem KillCooldown;
     private static OptionItem ConvertTime;
     private static OptionItem KillerConvertGhost;
 
-    private static List<byte> playerIdList = [];
     private static List<byte> GhostPlayer = [];
-    private static Dictionary<byte, PlayerControl> RealKiller = [];
+    private static readonly Dictionary<byte, PlayerControl> RealKiller = [];
 
     public static void SetupCustomOption()
     {
@@ -36,15 +37,13 @@ internal class Lightning : RoleBase
     }
     public override void Init()
     {
-        On = false;
-        playerIdList = [];
-        GhostPlayer = [];
-        RealKiller = [];
+        playerIdList.Clear();
+        GhostPlayer.Clear();
+        RealKiller.Clear();
     }
     public override void Add(byte playerId)
     {
         playerIdList.Add(playerId);
-        On = true;
 
         if (AmongUsClient.Instance.AmHost)
         {

--- a/Roles/Impostor/Ludopath.cs
+++ b/Roles/Impostor/Ludopath.cs
@@ -1,14 +1,19 @@
 ﻿
+using System.Collections.Generic;
+using System.Linq;
+
 namespace TOHE.Roles.Impostor;
 
 internal class Ludopath : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 1800;
-
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> PlayerIds = [];
+    public static bool HasEnabled => PlayerIds.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Impostor;
-    
+    //==================================================================\\
+
     private static OptionItem LudopathRandomKillCD;
 
     public static void SetupCustomOption()
@@ -20,11 +25,11 @@ internal class Ludopath : RoleBase
     }
     public override void Init()
     {
-        On = false;
+        PlayerIds.Clear();
     }
     public override void Add(byte playerId)
     {
-        On = true;
+        PlayerIds.Add(playerId);
     }
 
     public override void SetKillCooldown(byte id) => Main.AllPlayerKillCooldown[id] = LudopathRandomKillCD.GetFloat();

--- a/Roles/Impostor/Lurker.cs
+++ b/Roles/Impostor/Lurker.cs
@@ -1,20 +1,23 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using static TOHE.Options;
 
 namespace TOHE.Roles.Impostor;
 
 internal class Lurker : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 1900;
 
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> playerIdList = [];
+    public static bool HasEnabled => playerIdList.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Impostor;
+    //==================================================================\\
 
     private static OptionItem DefaultKillCooldown;
     private static OptionItem ReduceKillCooldown;
 
-    private static List<byte> playerIdList = [];
 
     public static void SetupCustomOption()
     {
@@ -26,13 +29,11 @@ internal class Lurker : RoleBase
     }
     public override void Init()
     {
-        On = false;
-        playerIdList = [];
+        playerIdList.Clear();
     }
     public override void Add(byte playerId)
     {
         playerIdList.Add(playerId);
-        On = true;
     }
 
     public  override void SetKillCooldown(byte id) => Main.AllPlayerKillCooldown[id] = DefaultKillCooldown.GetFloat();

--- a/Roles/Impostor/Mastermind.cs
+++ b/Roles/Impostor/Mastermind.cs
@@ -119,7 +119,7 @@ internal class Mastermind : RoleBase
                 TempKCDs.Remove(x.Key);
                 player.SetRealKiller(mastermind);
                 Main.PlayerStates[player.PlayerId].deathReason = PlayerState.DeathReason.Suicide;
-                player.RpcMurderPlayerV3(player);
+                player.RpcMurderPlayer(player);
                 RPC.PlaySoundRPC(mastermind.PlayerId, Sounds.KillSound);
             }
 
@@ -138,7 +138,7 @@ internal class Mastermind : RoleBase
             {
                 Main.PlayerStates[pc.PlayerId].deathReason = PlayerState.DeathReason.Suicide;
                 pc.SetRealKiller(GetPlayerById(playerIdList.First()));
-                pc.RpcMurderPlayerV3(pc);
+                pc.RpcMurderPlayer(pc);
             }
         }
         ManipulateDelays.Clear();
@@ -160,12 +160,12 @@ internal class Mastermind : RoleBase
 
         if (target.Is(CustomRoles.Pestilence) || target.Is(CustomRoles.Mastermind))
         {
-            target.RpcMurderPlayerV3(killer);
+            target.RpcMurderPlayer(killer);
             TempKCDs.Remove(killer.PlayerId);
             return false;
         }
 
-        killer.RpcMurderPlayerV3(target);
+        killer.RpcMurderPlayer(target);
 
         _ = new LateTask(() =>
         {

--- a/Roles/Impostor/Mastermind.cs
+++ b/Roles/Impostor/Mastermind.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using TOHE.Roles.Crewmate;
 using static TOHE.Options;
 using static TOHE.Translator;
@@ -8,20 +9,22 @@ namespace TOHE.Roles.Impostor;
 
 internal class Mastermind : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 4100;
 
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> playerIdList = [];
+    public static bool HasEnabled => playerIdList.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Impostor;
+    //==================================================================\\
 
     private static OptionItem KillCooldown;
     private static OptionItem TimeLimit;
     private static OptionItem Delay;
 
-    private static List<byte> playerIdList = [];
-    private static Dictionary<byte, long> ManipulatedPlayers = [];
-    private static Dictionary<byte, long> ManipulateDelays = [];
-    private static Dictionary<byte, float> TempKCDs = [];
+    private static readonly Dictionary<byte, long> ManipulatedPlayers = [];
+    private static readonly Dictionary<byte, long> ManipulateDelays = [];
+    private static readonly Dictionary<byte, float> TempKCDs = [];
 
     private static float ManipulateCD;
 
@@ -38,11 +41,10 @@ internal class Mastermind : RoleBase
 
     public override void Init()
     {
-        On = false;
-        playerIdList = [];
-        ManipulatedPlayers = [];
-        ManipulateDelays = [];
-        TempKCDs = [];
+        playerIdList.Clear();
+        ManipulatedPlayers.Clear();
+        ManipulateDelays.Clear();
+        TempKCDs.Clear();
     }
 
     public override void Add(byte playerId)
@@ -54,7 +56,6 @@ internal class Mastermind : RoleBase
         var pc = GetPlayerById(playerId);
         pc.AddDoubleTrigger();
 
-        On = true;
     }
 
     public override void SetKillCooldown(byte id) => Main.AllPlayerKillCooldown[id] = KillCooldown.GetFloat();
@@ -136,7 +137,7 @@ internal class Mastermind : RoleBase
             if (pc.IsAlive())
             {
                 Main.PlayerStates[pc.PlayerId].deathReason = PlayerState.DeathReason.Suicide;
-                pc.SetRealKiller(GetPlayerById(playerIdList[0]));
+                pc.SetRealKiller(GetPlayerById(playerIdList.First()));
                 pc.RpcMurderPlayerV3(pc);
             }
         }
@@ -152,7 +153,7 @@ internal class Mastermind : RoleBase
 
         ManipulatedPlayers.Remove(killer.PlayerId);
 
-        var mastermind = GetPlayerById(playerIdList[0]);
+        var mastermind = GetPlayerById(playerIdList.First());
         mastermind?.Notify(string.Format(GetString("ManipulatedKilled"), target.GetRealName()), 4f);
         mastermind?.SetKillCooldown(time: KillCooldown.GetFloat());
         killer.Notify(GetString("SurvivedManipulation"));

--- a/Roles/Impostor/Mercenary.cs
+++ b/Roles/Impostor/Mercenary.cs
@@ -1,5 +1,6 @@
 using AmongUs.GameOptions;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using static TOHE.Translator;
 
@@ -7,17 +8,18 @@ namespace TOHE.Roles.Impostor;
 
 internal class Mercenary : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 2000;
-
-    public static bool On;
-    public override bool IsEnable => On;
+    public static readonly HashSet<byte> playerIdList = [];
+    public static bool HasEnabled => playerIdList.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Shapeshifter;
+    //==================================================================\\
 
     private static OptionItem KillCooldown;
     private static OptionItem TimeLimit;
 
-    public static List<byte> playerIdList = [];
-    private static Dictionary<byte, float> SuicideTimer = [];
+    private static readonly Dictionary<byte, float> SuicideTimer = [];
 
     private static float OptTimeLimit;
 
@@ -31,15 +33,13 @@ internal class Mercenary : RoleBase
     }
     public override void Init()
     {
-        On = false;
-        playerIdList = [];
-        SuicideTimer = [];
+        playerIdList.Clear();
+        SuicideTimer.Clear();
     }
     public override void Add(byte serial)
     {
         playerIdList.Add(serial);
         OptTimeLimit = TimeLimit.GetFloat();
-        On = true;
     }
 
     private static bool HasKilled(PlayerControl pc)

--- a/Roles/Impostor/Mercenary.cs
+++ b/Roles/Impostor/Mercenary.cs
@@ -90,7 +90,7 @@ internal class Mercenary : RoleBase
         else if (timer >= OptTimeLimit)
         {
             Main.PlayerStates[player.PlayerId].deathReason = PlayerState.DeathReason.Suicide;
-            player.RpcMurderPlayerV3(player);
+            player.RpcMurderPlayer(player);
             SuicideTimer.Remove(player.PlayerId);
         }
         else

--- a/Roles/Impostor/Miner.cs
+++ b/Roles/Impostor/Miner.cs
@@ -1,14 +1,19 @@
 ﻿using AmongUs.GameOptions;
+using System.Collections.Generic;
+using System.Linq;
 using TOHE.Modules;
 
 namespace TOHE.Roles.Impostor;
 
 internal class Miner : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 4200;
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> PlayerIds = [];
+    public static bool HasEnabled => PlayerIds.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Shapeshifter;
+    //==================================================================\\
 
     private static OptionItem MinerSSDuration;
     private static OptionItem MinerSSCD;
@@ -25,11 +30,11 @@ internal class Miner : RoleBase
     }
     public override void Init()
     {
-        On = false;
+        PlayerIds.Clear();
     }
     public override void Add(byte playerId)
     {
-        On = true;
+        PlayerIds.Add(playerId);
     }
 
     public override void ApplyGameOptions(IGameOptions opt, byte playerId)

--- a/Roles/Impostor/Morphling.cs
+++ b/Roles/Impostor/Morphling.cs
@@ -1,21 +1,24 @@
 using AmongUs.GameOptions;
 using System.Collections.Generic;
+using System.Linq;
 using static TOHE.Options;
 
 namespace TOHE.Roles.Impostor;
 
 internal class Morphling : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 3500;
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> playerIdList = [];
+    public static bool HasEnabled => playerIdList.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Shapeshifter;
+    //===========================SETUP================================\\
 
     private static OptionItem KillCooldown;
     private static OptionItem ShapeshiftCD;
     private static OptionItem ShapeshiftDur;
 
-    private static List<byte> playerIdList = [];
 
     public static void SetupCustomOption()
     {
@@ -29,13 +32,11 @@ internal class Morphling : RoleBase
     }
     public override void Init()
     {
-        On = false;
-        playerIdList = [];
+        playerIdList.Clear();
     }
     public override void Add(byte playerId)
     {
         playerIdList.Add(playerId);
-        On = true;
     }
 
     public override bool CanUseKillButton(PlayerControl player)

--- a/Roles/Impostor/Nemesis.cs
+++ b/Roles/Impostor/Nemesis.cs
@@ -149,6 +149,12 @@ internal class Nemesis : RoleBase
             else pc.ShowPopUp(GetString("GuessSolsticer"));
             return true;
         }
+        else if (!pc.RpcCheckAndMurder(target, true))
+        {
+            if (!isUI) Utils.SendMessage(GetString("GuessImmune"), pc.PlayerId);
+            else pc.ShowPopUp(GetString("GuessImmune"));
+            return true;
+        }
 
         Logger.Info($"{pc.GetNameWithRole()} 复仇了 {target.GetNameWithRole()}", "Nemesis");
 

--- a/Roles/Impostor/Nemesis.cs
+++ b/Roles/Impostor/Nemesis.cs
@@ -15,10 +15,13 @@ namespace TOHE.Roles.Impostor;
 
 internal class Nemesis : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 3600;
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> PlayerIds = [];
+    public static bool HasEnabled => PlayerIds.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => LegacyNemesis.GetBool() ? CustomRoles.Shapeshifter : CustomRoles.Impostor;
+    //==================================================================\\
 
     private static OptionItem NemesisCanKillNum;
     public static OptionItem LegacyNemesis;
@@ -45,11 +48,11 @@ internal class Nemesis : RoleBase
     public override void Init()
     {
         NemesisRevenged.Clear();
-        On = false;
+        PlayerIds.Clear();
     }
     public override void Add(byte playerId)
     {
-        On = true;
+        PlayerIds.Add(playerId);
     }
 
     public override void ApplyGameOptions(IGameOptions opt, byte playerId)

--- a/Roles/Impostor/Nemesis.cs
+++ b/Roles/Impostor/Nemesis.cs
@@ -168,7 +168,7 @@ internal class Nemesis : RoleBase
             }
             else
             {
-                target.RpcMurderPlayerV3(target);
+                target.RpcMurderPlayer(target);
                 Utils.NotifyRoles(NoCache: true);
             }
             target.SetRealKiller(pc);

--- a/Roles/Impostor/Ninja.cs
+++ b/Roles/Impostor/Ninja.cs
@@ -1,6 +1,7 @@
 ﻿using AmongUs.GameOptions;
 using Hazel;
 using System.Collections.Generic;
+using System.Linq;
 using TOHE.Modules;
 using TOHE.Roles.Crewmate;
 using TOHE.Roles.Neutral;
@@ -12,17 +13,19 @@ namespace TOHE.Roles.Impostor;
 
 internal class Ninja : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 2100;
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> playerIdList = [];
+    public static bool HasEnabled => playerIdList.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Shapeshifter;
+    //==================================================================\\
 
     private static OptionItem MarkCooldown;
     private static OptionItem AssassinateCooldown;
     private static OptionItem CanKillAfterAssassinate;
 
-    private static List<byte> playerIdList = [];
-    private static Dictionary<byte, byte> MarkedPlayer = [];
+    private static readonly Dictionary<byte, byte> MarkedPlayer = [];
 
     public static void SetupCustomOption()
     {
@@ -35,14 +38,12 @@ internal class Ninja : RoleBase
     }
     public override void Init()
     {
-        On = false;
-        playerIdList = [];
-        MarkedPlayer = [];
+        playerIdList.Clear();
+        MarkedPlayer.Clear();
     }
     public override void Add(byte playerId)
     {
         playerIdList.Add(playerId);
-        On = true;
     }
 
     private static void SendRPC(byte playerId)

--- a/Roles/Impostor/Parasite.cs
+++ b/Roles/Impostor/Parasite.cs
@@ -1,14 +1,19 @@
 ﻿
 using AmongUs.GameOptions;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace TOHE.Roles.Impostor;
 
 internal class Parasite : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 5900;
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> Playerids = [];
+    public static bool HasEnabled => Playerids.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Impostor;
+    //==================================================================\\
 
     private static OptionItem ParasiteCD;
 
@@ -21,11 +26,11 @@ internal class Parasite : RoleBase
     }
     public override void Init()
     {
-        On = false;
+        Playerids.Clear();
     }
     public override void Add(byte playerId)
     {
-        On = true;
+        Playerids.Add(playerId);
     }
 
     public override void ApplyGameOptions(IGameOptions opt, byte playerId) => opt.SetVision(true);

--- a/Roles/Impostor/Penguin.cs
+++ b/Roles/Impostor/Penguin.cs
@@ -4,21 +4,24 @@ using System.Collections.Generic;
 using UnityEngine;
 using static TOHE.Translator;
 using static TOHE.Options;
+using System.Linq;
 
 // https://github.com/tukasa0001/TownOfHost/blob/main/Roles/Impostor/Penguin.cs
 namespace TOHE.Roles.Impostor;
 
 internal class Penguin : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 27500;
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> playerIdList = [];
+    public static bool HasEnabled => playerIdList.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Shapeshifter;
+    //==================================================================\\
 
     private static OptionItem OptionAbductTimerLimit;
     private static OptionItem OptionMeetingKill;
 
-    private static List<byte> playerIdList = [];
 
     public static PlayerControl AbductVictim;
     private static float AbductTimer;
@@ -39,8 +42,7 @@ internal class Penguin : RoleBase
     }
     public override void Init()
     {
-        On = false;
-        playerIdList = [];
+        playerIdList.Clear();
     }
     public override void Add(byte playerId)
     {
@@ -51,7 +53,6 @@ internal class Penguin : RoleBase
 
         AbductTimer = 255f;
         stopCount = false;
-        On = true;
     }
 
     public override void ApplyGameOptions(IGameOptions opt, byte playerId)
@@ -101,8 +102,8 @@ internal class Penguin : RoleBase
         }
         //MyState.CanUseMovingPlatform = true;
         AbductTimer = 255f;
-        Utils.GetPlayerById(playerIdList[0])?.MarkDirtySettings();
-        Utils.GetPlayerById(playerIdList[0])?.RpcResetAbilityCooldown();
+        Utils.GetPlayerById(playerIdList.First())?.MarkDirtySettings();
+        Utils.GetPlayerById(playerIdList.First())?.RpcResetAbilityCooldown();
         SendRPC();
     }
     public override bool OnCheckMurderAsKiller(PlayerControl killer, PlayerControl target)
@@ -145,13 +146,13 @@ internal class Penguin : RoleBase
         // If you meet a meeting with time running out, kill it even if you're on a ladder.
         if (AbductVictim != null && AbductTimer <= 0f)
         {
-            Utils.GetPlayerById(playerIdList[0])?.RpcMurderPlayerV3(AbductVictim);
+            Utils.GetPlayerById(playerIdList.First())?.RpcMurderPlayerV3(AbductVictim);
         }
         if (MeetingKill)
         {
             if (!AmongUsClient.Instance.AmHost) return;
             if (AbductVictim == null) return;
-            Utils.GetPlayerById(playerIdList[0])?.RpcMurderPlayerV3(AbductVictim);
+            Utils.GetPlayerById(playerIdList.First())?.RpcMurderPlayerV3(AbductVictim);
             RemoveVictim();
         }
     }
@@ -168,11 +169,11 @@ internal class Penguin : RoleBase
     }
     private static void RestartAbduct()
     {
-        if (!On) return;
+        if (!HasEnabled) return;
         if (AbductVictim != null)
         {
-            Utils.GetPlayerById(playerIdList[0])?.MarkDirtySettings();
-            Utils.GetPlayerById(playerIdList[0])?.RpcResetAbilityCooldown();
+            Utils.GetPlayerById(playerIdList.First())?.MarkDirtySettings();
+            Utils.GetPlayerById(playerIdList.First())?.RpcResetAbilityCooldown();
             stopCount = false;
         }
     }

--- a/Roles/Impostor/Penguin.cs
+++ b/Roles/Impostor/Penguin.cs
@@ -114,7 +114,7 @@ internal class Penguin : RoleBase
             if (target != AbductVictim)
             {
                 // During an abduction, only the abductee can be killed.
-                killer?.RpcMurderPlayerV3(AbductVictim);
+                killer?.RpcMurderPlayer(AbductVictim);
                 killer?.ResetKillCooldown();
                 doKill = false;
             }
@@ -146,13 +146,13 @@ internal class Penguin : RoleBase
         // If you meet a meeting with time running out, kill it even if you're on a ladder.
         if (AbductVictim != null && AbductTimer <= 0f)
         {
-            Utils.GetPlayerById(playerIdList.First())?.RpcMurderPlayerV3(AbductVictim);
+            Utils.GetPlayerById(playerIdList.First())?.RpcMurderPlayer(AbductVictim);
         }
         if (MeetingKill)
         {
             if (!AmongUsClient.Instance.AmHost) return;
             if (AbductVictim == null) return;
-            Utils.GetPlayerById(playerIdList.First())?.RpcMurderPlayerV3(AbductVictim);
+            Utils.GetPlayerById(playerIdList.First())?.RpcMurderPlayer(AbductVictim);
             RemoveVictim();
         }
     }

--- a/Roles/Impostor/Penguin.cs
+++ b/Roles/Impostor/Penguin.cs
@@ -67,7 +67,7 @@ internal class Penguin : RoleBase
         writer.Write(AbductVictim?.PlayerId ?? 255);
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         var victim = reader.ReadByte();
 

--- a/Roles/Impostor/Pitfall.cs
+++ b/Roles/Impostor/Pitfall.cs
@@ -11,10 +11,13 @@ namespace TOHE.Roles.Impostor;
 
 internal class Pitfall : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 5600;
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> playerIdList = [];
+    public static bool HasEnabled => playerIdList.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Shapeshifter;
+    //==================================================================\\
 
     private static OptionItem ShapeshiftCooldown;
     private static OptionItem MaxTrapCount;
@@ -25,7 +28,6 @@ internal class Pitfall : RoleBase
     private static OptionItem TrapCauseVision;
     private static OptionItem TrapCauseVisionTime;
 
-    private static HashSet<byte> playerIdList = [];
     private static List<PitfallTrap> Traps = [];
     private static List<byte> ReducedVisionPlayers = [];
 
@@ -55,8 +57,7 @@ internal class Pitfall : RoleBase
     }
     public override void Init()
     {
-        On = false;
-        playerIdList = [];
+        playerIdList.Clear();
         Traps = [];
         ReducedVisionPlayers = [];
         DefaultSpeed = new();
@@ -70,7 +71,6 @@ internal class Pitfall : RoleBase
 
         TrapMaxPlayerCount = TrapMaxPlayerCountOpt.GetFloat();
         TrapDuration = TrapDurationOpt.GetFloat();
-        On = true;
 
         if (AmongUsClient.Instance.AmHost)
         {

--- a/Roles/Impostor/Puppeteer.cs
+++ b/Roles/Impostor/Puppeteer.cs
@@ -137,7 +137,7 @@ internal class Puppeteer : RoleBase
                         var puppeteerId = PuppeteerList[puppet.PlayerId];
                         RPC.PlaySoundRPC(puppeteerId, Sounds.KillSound);
                         target.SetRealKiller(Utils.GetPlayerById(puppeteerId));
-                        puppet.RpcMurderPlayerV3(target);
+                        puppet.RpcMurderPlayer(target);
                         Utils.MarkEveryoneDirtySettings();
                         PuppeteerList.Remove(puppet.PlayerId);
                         SendRPC(byte.MaxValue, puppet.PlayerId, 2);
@@ -149,7 +149,7 @@ internal class Puppeteer : RoleBase
                             
                             Main.PlayerStates[puppet.PlayerId].deathReason = PlayerState.DeathReason.Drained;
                             puppet.SetRealKiller(Utils.GetPlayerById(puppeteerId));
-                            puppet.RpcMurderPlayerV3(puppet);
+                            puppet.RpcMurderPlayer(puppet);
                         }
                     }
                 }

--- a/Roles/Impostor/Puppeteer.cs
+++ b/Roles/Impostor/Puppeteer.cs
@@ -15,10 +15,13 @@ namespace TOHE.Roles.Impostor;
 
 internal class Puppeteer : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 4300;
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> PlayerIds = [];
+    public static bool HasEnabled => PlayerIds.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Impostor;
+    //==================================================================\\
 
     private static OptionItem PuppeteerDoubleKills;
 
@@ -32,8 +35,8 @@ internal class Puppeteer : RoleBase
     }
     public override void Init()
     {
-        On = false;
-        PuppeteerList = [];
+        PlayerIds.Clear();
+        PuppeteerList.Clear();
     }
     public override void Add(byte playerId)
     {
@@ -41,7 +44,7 @@ internal class Puppeteer : RoleBase
         var pc = Utils.GetPlayerById(playerId);
         pc.AddDoubleTrigger();
 
-        On = true;
+        PlayerIds.Add(playerId);
 
         if (AmongUsClient.Instance.AmHost)
         {

--- a/Roles/Impostor/QuickShooter.cs
+++ b/Roles/Impostor/QuickShooter.cs
@@ -2,22 +2,25 @@
 using Hazel;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 namespace TOHE.Roles.Impostor;
 
 internal class QuickShooter : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 2200;
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> playerIdList = [];
+    public static bool HasEnabled => playerIdList.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Shapeshifter;
+    //==================================================================\\
 
     private static OptionItem KillCooldown;
     private static OptionItem MeetingReserved;
     private static OptionItem ShapeshiftCooldown;
 
-    private static List<byte> playerIdList = [];
     private static Dictionary<byte, int> ShotLimit = [];
 
     private static bool Storaging = false;
@@ -34,16 +37,14 @@ internal class QuickShooter : RoleBase
     }
     public override void Init()
     {
-        On = false;
-        playerIdList = [];
-        ShotLimit = [];
+        playerIdList.Clear();
+        ShotLimit.Clear();
         Storaging = false;
     }
     public override void Add(byte playerId)
     {
         playerIdList.Add(playerId);
         ShotLimit.TryAdd(playerId, 0);
-        On = true;
     }
 
     private static void SendRPC(byte playerId)

--- a/Roles/Impostor/QuickShooter.cs
+++ b/Roles/Impostor/QuickShooter.cs
@@ -54,7 +54,7 @@ internal class QuickShooter : RoleBase
         writer.Write(ShotLimit[playerId]);
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         byte QuickShooterId = reader.ReadByte();
         int Limit = reader.ReadInt32();

--- a/Roles/Impostor/Refugee.cs
+++ b/Roles/Impostor/Refugee.cs
@@ -1,14 +1,19 @@
 ﻿
 using AmongUs.GameOptions;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace TOHE.Roles.Impostor;
 
 internal class Refugee : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 60009;
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> PlayerIds = [];
+    public static bool HasEnabled => PlayerIds.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Impostor;
+    //==================================================================\\
 
     private static OptionItem RefugeeKillCD;
 
@@ -21,11 +26,11 @@ internal class Refugee : RoleBase
     }
     public override void Init()
     {
-        On = false;
+        PlayerIds.Clear();
     }
     public override void Add(byte playerId)
     {
-        On = true;
+        PlayerIds.Add(playerId);
     }
     public override void ApplyGameOptions(IGameOptions opt, byte playerId) => opt.SetVision(true);
     public override void SetKillCooldown(byte id) => Main.AllPlayerKillCooldown[id] = RefugeeKillCD.GetFloat();

--- a/Roles/Impostor/RiftMaker.cs
+++ b/Roles/Impostor/RiftMaker.cs
@@ -10,18 +10,21 @@ namespace TOHE.Roles.Impostor;
 
 internal class RiftMaker : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 27200;
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> Playerids = [];
+    public static bool HasEnabled => Playerids.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Shapeshifter;
+    //==================================================================\\
 
     private static OptionItem SSCooldown;
     private static OptionItem KillCooldown;
     private static OptionItem TPCooldownOpt;
     private static OptionItem RiftRadius;
 
-    private static Dictionary<byte, List<Vector2>> MarkedLocation = [];
-    private static Dictionary<byte, long> LastTP = [];
+    private static readonly Dictionary<byte, List<Vector2>> MarkedLocation = [];
+    private static readonly Dictionary<byte, long> LastTP = [];
     private static float TPCooldown = new();
 
     public static void SetupCustomOption()
@@ -39,18 +42,18 @@ internal class RiftMaker : RoleBase
 
     public override void Init()
     {
-        On = false;
-        MarkedLocation = [];
-        LastTP = [];
+        Playerids.Clear();
+        MarkedLocation.Clear();
+        LastTP.Clear();
         TPCooldown = new();
     }
     public override void Add(byte playerId)
     {
-        MarkedLocation[playerId] = [];
+        MarkedLocation[playerId].Clear();
         var now = Utils.GetTimeStamp();
         LastTP[playerId] = now;
         TPCooldown = TPCooldownOpt.GetFloat();
-        On = true;
+        Playerids.Add(playerId);
     }
 
     private static void SendRPC(byte riftID, int operate)

--- a/Roles/Impostor/Saboteur.cs
+++ b/Roles/Impostor/Saboteur.cs
@@ -1,12 +1,18 @@
 ﻿
+using System.Collections.Generic;
+using System.Linq;
+
 namespace TOHE.Roles.Impostor;
 
 internal class Saboteur : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 2300;
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> PlayerIds = [];
+    public static bool HasEnabled => PlayerIds.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Impostor;
+    //==================================================================\\
 
     private static OptionItem SaboteurCD;
 
@@ -19,11 +25,11 @@ internal class Saboteur : RoleBase
     }
     public override void Init()
     {
-        On = false;
+        PlayerIds.Clear();
     }
     public override void Add(byte playerId)
     {
-        On = true;
+        PlayerIds.Add(playerId);
     }
 
     public override void SetKillCooldown(byte id) => Main.AllPlayerKillCooldown[id] = SaboteurCD.GetFloat();

--- a/Roles/Impostor/Scavenger.cs
+++ b/Roles/Impostor/Scavenger.cs
@@ -1,12 +1,18 @@
 ﻿
+using System.Collections.Generic;
+using System.Linq;
+
 namespace TOHE.Roles.Impostor;
 
 internal class Scavenger : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 4400;
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> PlayerIds = [];
+    public static bool HasEnabled => PlayerIds.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Impostor;
+    //==================================================================\\
 
     private static OptionItem ScavengerKillCooldown;
 
@@ -19,11 +25,11 @@ internal class Scavenger : RoleBase
     }
     public override void Init()
     {
-        On = false;
+        PlayerIds.Clear();
     }
     public override void Add(byte playerId)
     {
-        On = true;
+        PlayerIds.Add(playerId);
     }
 
     public override void SetKillCooldown(byte id) => Main.AllPlayerKillCooldown[id] = ScavengerKillCooldown.GetFloat();

--- a/Roles/Impostor/Scavenger.cs
+++ b/Roles/Impostor/Scavenger.cs
@@ -42,7 +42,7 @@ internal class Scavenger : RoleBase
             () =>
             {
                 target.SetRealKiller(killer);
-                target.RpcMurderPlayerV3(target);
+                target.RpcMurderPlayer(target);
                 target.Notify(Utils.ColorString(Utils.GetRoleColor(CustomRoles.Scavenger), Translator.GetString("KilledByScavenger")), time: 8f);
             },
             0.5f, "Scavenger Kill");

--- a/Roles/Impostor/ShapeMaster.cs
+++ b/Roles/Impostor/ShapeMaster.cs
@@ -1,13 +1,18 @@
 ﻿using AmongUs.GameOptions;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace TOHE.Roles.Impostor;
 
-internal class ShapeMaster : RoleBase
+internal class ShapeMaster : RoleBase // Should be deleted tbh, because it's litteraly vanilla shapeshifter
 {
+    //===========================SETUP================================\\
     private const int Id = 4500;
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> Playerids = [];
+    public static bool HasEnabled => Playerids.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Shapeshifter;
+    //==================================================================\\
 
     private static OptionItem ShapeMasterShapeshiftDuration;
 
@@ -20,11 +25,11 @@ internal class ShapeMaster : RoleBase
     }
     public override void Init()
     {
-        On = false;
+        Playerids.Clear();
     }
     public override void Add(byte playerId)
     {
-        On = true;
+        Playerids.Add     (playerId);
     }
 
     public override void ApplyGameOptions(IGameOptions opt, byte playerId)

--- a/Roles/Impostor/Sniper.cs
+++ b/Roles/Impostor/Sniper.cs
@@ -11,10 +11,13 @@ namespace TOHE.Roles.Impostor;
 
 internal class Sniper : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 2400;
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> PlayerIdList = [];
+    public static bool HasEnabled => PlayerIdList.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Shapeshifter;
+    //==================================================================\\
 
     private static OptionItem SniperBulletCount;
     private static OptionItem SniperPrecisionShooting;
@@ -23,14 +26,13 @@ internal class Sniper : RoleBase
     private static OptionItem CanKillWithBullets;
     private static OptionItem AlwaysShowShapeshiftAnimations;
 
-    private static List<byte> PlayerIdList = [];
-    private static Dictionary<byte, byte> snipeTarget = [];
-    private static Dictionary<byte, Vector3> snipeBasePosition = [];
-    private static Dictionary<byte, Vector3> LastPosition = [];
-    private static Dictionary<byte, int> bulletCount = [];
-    private static Dictionary<byte, List<byte>> shotNotify = [];
-    private static Dictionary<byte, bool> IsAim = [];
-    private static Dictionary<byte, float> AimTime = [];
+    private static readonly Dictionary<byte, byte> snipeTarget = [];
+    private static readonly Dictionary<byte, Vector3> snipeBasePosition = [];
+    private static readonly Dictionary<byte, Vector3> LastPosition = [];
+    private static readonly Dictionary<byte, int> bulletCount = [];
+    private static readonly Dictionary<byte, List<byte>> shotNotify = [];
+    private static readonly Dictionary<byte, bool> IsAim = [];
+    private static readonly Dictionary<byte, float> AimTime = [];
 
     private static bool meetingReset;
     private static int maxBulletCount;
@@ -53,19 +55,17 @@ internal class Sniper : RoleBase
     }
     public override void Init()
     {
-        On = false;
-
         Logger.Disable("Sniper");
 
-        PlayerIdList = [];
+        PlayerIdList.Clear();
 
-        snipeBasePosition = [];
-        LastPosition = [];
-        snipeTarget = [];
-        bulletCount = [];
-        shotNotify = [];
-        IsAim = [];
-        AimTime = [];
+        snipeBasePosition.Clear();
+        LastPosition.Clear();
+        snipeTarget.Clear();
+        bulletCount.Clear();
+        shotNotify.Clear();
+        IsAim.Clear();
+        AimTime.Clear();
         meetingReset = false;
     }
     public override void Add(byte playerId)
@@ -86,8 +86,6 @@ internal class Sniper : RoleBase
         shotNotify[playerId] = [];
         IsAim[playerId] = false;
         AimTime[playerId] = 0f;
-
-        On = true;
 
         if (AmongUsClient.Instance.AmHost)
         {
@@ -293,7 +291,7 @@ internal class Sniper : RoleBase
     }
     public static void OnFixedUpdateGlobal(PlayerControl pc)
     {
-        if (!On || !IsThisRole(pc.PlayerId) || !pc.IsAlive()) return;
+        if (!HasEnabled || !IsThisRole(pc.PlayerId) || !pc.IsAlive()) return;
 
         if (!AimAssist) return;
 
@@ -345,7 +343,7 @@ internal class Sniper : RoleBase
     {
         if (isForMeeting) return string.Empty;
         seen ??= seer;
-        var sniper = Utils.GetPlayerById(PlayerIdList[0]);
+        var sniper = Utils.GetPlayerById(PlayerIdList.First());
         if (!(sniper == seer) || !(sniper == seen)) return string.Empty;
         
         var seerId = seer.PlayerId;

--- a/Roles/Impostor/SoulCatcher.cs
+++ b/Roles/Impostor/SoulCatcher.cs
@@ -1,4 +1,6 @@
 ﻿using AmongUs.GameOptions;
+using System.Collections.Generic;
+using System.Linq;
 using TOHE.Modules;
 using UnityEngine;
 
@@ -6,10 +8,13 @@ namespace TOHE.Roles.Impostor;
 
 internal class SoulCatcher : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 4600;
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> PlayerIds = [];
+    public static bool HasEnabled => PlayerIds.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Shapeshifter;
+    //==================================================================\\
 
     private static OptionItem ShapeSoulCatcherShapeshiftDuration;
     private static OptionItem SoulCatcherShapeshiftCooldown;
@@ -26,11 +31,11 @@ internal class SoulCatcher : RoleBase
     }
     public override void Init()
     {
-        On = false;
+        PlayerIds.Clear();
     }
     public override void Add(byte playerId)
     {
-        On = true;
+        PlayerIds.Add(playerId);
     }
 
     public override void ApplyGameOptions(IGameOptions opt, byte playerId)

--- a/Roles/Impostor/Stealth.cs
+++ b/Roles/Impostor/Stealth.cs
@@ -8,11 +8,13 @@ namespace TOHE.Roles.Impostor;
 // https://github.com/tukasa0001/TownOfHost/blob/main/Roles/Impostor/Stealth.cs
 internal class Stealth : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 27400;
-    private static List<byte> playerIdList = [];
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> playerIdList = [];
+    public static bool HasEnabled => playerIdList.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Impostor;
+    //==================================================================\\
 
     private static OptionItem optionExcludeImpostors;
     private static OptionItem optionDarkenDuration;
@@ -35,8 +37,7 @@ internal class Stealth : RoleBase
 
     public override void Init()
     {
-        On = false;
-        playerIdList = [];
+        playerIdList.Clear();
     }
     public override void Add(byte playerId)
     {
@@ -45,7 +46,6 @@ internal class Stealth : RoleBase
         darkenedPlayers = null;
 
         playerIdList.Add(playerId);
-        On = true;
     }
     public override bool OnCheckMurderAsKiller(PlayerControl killer, PlayerControl target)
     {
@@ -74,7 +74,7 @@ internal class Stealth : RoleBase
         var roomArea = room.roomArea;
         var roomName = room.RoomId;
         RpcDarken(roomName);
-        return Main.AllAlivePlayerControls.Where(player => player != Utils.GetPlayerById(playerIdList[0]) && player.Collider.IsTouching(roomArea)).ToArray();
+        return Main.AllAlivePlayerControls.Where(player => player != Utils.GetPlayerById(playerIdList.First()) && player.Collider.IsTouching(roomArea)).ToArray();
     }
     /// <summary>Give the given player zero visibility for <see cref="darkenDuration"/> seconds.</summary>
     private static void DarkenPlayers(PlayerControl[] playersToDarken)
@@ -138,15 +138,15 @@ internal class Stealth : RoleBase
         }
         darkenTimer = darkenDuration;
         RpcDarken(null);
-        Utils.NotifyRoles(SpecifySeer: Utils.GetPlayerById(playerIdList[0]), SpecifyTarget: Utils.GetPlayerById(playerIdList[0]));
+        Utils.NotifyRoles(SpecifySeer: Utils.GetPlayerById(playerIdList.First()), SpecifyTarget: Utils.GetPlayerById(playerIdList.First()));
     }
     public override string GetLowerText(PlayerControl seer, PlayerControl seen = null, bool isForMeeting = false, bool isForHud = false)
     {
         seen ??= seer;
-        var Player = Utils.GetPlayerById(playerIdList[0]);
+        var Player = Utils.GetPlayerById(playerIdList.First());
 
         // During the meeting, unless it's my suffix or it's dark everywhere, I won't show anything.
-        if (!On || isForMeeting || seer != Player || seen != Player || !darkenedRoom.HasValue)
+        if (!HasEnabled || isForMeeting || seer != Player || seen != Player || !darkenedRoom.HasValue)
         {
             return string.Empty;
         }

--- a/Roles/Impostor/Stealth.cs
+++ b/Roles/Impostor/Stealth.cs
@@ -119,7 +119,7 @@ internal class Stealth : RoleBase
         writer.Write((byte?)roomType ?? byte.MaxValue);
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         var roomId = reader.ReadByte();
         darkenedRoom = roomId == byte.MaxValue ? null : (SystemTypes)roomId;

--- a/Roles/Impostor/Swooper.cs
+++ b/Roles/Impostor/Swooper.cs
@@ -59,7 +59,7 @@ internal class Swooper : RoleBase
         writer.Write((lastTime.TryGetValue(pc.PlayerId, out var y) ? y : -1).ToString());
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         InvisTime = [];
         lastTime = [];

--- a/Roles/Impostor/Swooper.cs
+++ b/Roles/Impostor/Swooper.cs
@@ -11,16 +11,18 @@ namespace TOHE.Roles.Impostor;
 
 internal class Swooper : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 4700;
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> playerIdList = [];
+    public static bool HasEnabled => playerIdList.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Impostor;
+    //==================================================================\\
 
     private static OptionItem SwooperCooldown;
     private static OptionItem SwooperDuration;
     private static OptionItem SwooperVentNormallyOnCooldown;
 
-    private static List<byte> playerIdList = [];
     private static Dictionary<byte, long> InvisTime = [];
     private static Dictionary<byte, long> lastTime = [];
     private static Dictionary<byte, int> ventedId = [];
@@ -38,17 +40,15 @@ internal class Swooper : RoleBase
     }
     public override void Init()
     {
-        playerIdList = [];
-        InvisTime = [];
-        lastTime = [];
-        ventedId = [];
+        playerIdList.Clear();
+        InvisTime.Clear();
+        lastTime.Clear();
+        ventedId.Clear();
         lastFixedTime = 0;
-        On = false;
     }
     public override void Add(byte playerId)
     {
         playerIdList.Add(playerId);
-        On = true;
     }
     private static void SendRPC(PlayerControl pc)
     {

--- a/Roles/Impostor/TimeThief.cs
+++ b/Roles/Impostor/TimeThief.cs
@@ -1,22 +1,24 @@
 using System.Collections.Generic;
+using System.Linq;
 using TOHE.Roles.Core;
 
 namespace TOHE.Roles.Impostor;
 
 internal class TimeThief : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 3700;
-    public static bool On;
-    public override bool IsEnable => On;
-    public static bool HasEnabled => CustomRoles.TimeThief.HasEnabled();
+    private static readonly HashSet<byte> playerIdList = [];
+    public static bool HasEnabled => playerIdList.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Impostor;
+    //==================================================================\\
 
     private static OptionItem KillCooldown;
     private static OptionItem DecreaseMeetingTime;
     public static OptionItem LowerLimitVotingTime;
     private static OptionItem ReturnStolenTimeUponDeath;
 
-    private static List<byte> playerIdList = [];
 
     public static void SetupCustomOption()
     {
@@ -31,13 +33,11 @@ internal class TimeThief : RoleBase
     }
     public override void Init()
     {
-        On = false;
-        playerIdList = [];
+        playerIdList.Clear();
     }
     public override void Add(byte playerId)
     {
         playerIdList.Add(playerId);
-        On = true;
     }
 
     public override void SetKillCooldown(byte id) => Main.AllPlayerKillCooldown[id] = KillCooldown.GetFloat();

--- a/Roles/Impostor/Trapster.cs
+++ b/Roles/Impostor/Trapster.cs
@@ -57,7 +57,8 @@ internal class Trapster : RoleBase
     public override bool OnCheckReportDeadBody(PlayerControl reporter, GameData.PlayerInfo deadBody, PlayerControl killer)
     {
         var target  = deadBody?.Object;
-        
+        var Trapsters = Playerids.GetPlayerListByIds();
+
         // if trapster dead
         if (target.Is(CustomRoles.Trapster) && TrapTrapsterBody.GetBool() && !reporter.Is(CustomRoles.Pestilence))
         {
@@ -78,7 +79,8 @@ internal class Trapster : RoleBase
         }
 
         // if reporter try reported trap body
-        if (BoobyTrapBody.Contains(target.PlayerId) && reporter.IsAlive() && !reporter.Is(CustomRoles.Pestilence))
+        if (BoobyTrapBody.Contains(target.PlayerId) && reporter.IsAlive()
+            && !reporter.Is(CustomRoles.Pestilence) && Trapsters.All(Trapi => Trapi.RpcCheckAndMurder(reporter, true)))
         {
             var killerId = target.PlayerId;
             

--- a/Roles/Impostor/Trapster.cs
+++ b/Roles/Impostor/Trapster.cs
@@ -65,7 +65,7 @@ internal class Trapster : RoleBase
 
             Main.PlayerStates[reporter.PlayerId].deathReason = PlayerState.DeathReason.Trap;
             reporter.SetRealKiller(target);
-            reporter.RpcMurderPlayerV3(reporter);
+            reporter.RpcMurderPlayer(reporter);
             
             RPC.PlaySoundRPC(killerId, Sounds.KillSound);
             
@@ -84,7 +84,7 @@ internal class Trapster : RoleBase
             
             Main.PlayerStates[reporter.PlayerId].deathReason = PlayerState.DeathReason.Trap;
             reporter.SetRealKiller(target);
-            reporter.RpcMurderPlayerV3(reporter);
+            reporter.RpcMurderPlayer(reporter);
             
             RPC.PlaySoundRPC(killerId, Sounds.KillSound);
             if (TrapConsecutiveBodies.GetBool())

--- a/Roles/Impostor/Trapster.cs
+++ b/Roles/Impostor/Trapster.cs
@@ -1,21 +1,25 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 
 namespace TOHE.Roles.Impostor;
 
 internal class Trapster : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 2600;
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> Playerids = [];
+    public static bool HasEnabled => Playerids.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Impostor;
+    //==================================================================\\
 
     private static OptionItem TrapsterKillCooldown;
     private static OptionItem TrapConsecutiveBodies;
     private static OptionItem TrapTrapsterBody;
     private static OptionItem TrapConsecutiveTrapsterBodies;
 
-    private static List<byte> BoobyTrapBody = [];
-    private static Dictionary<byte, byte> KillerOfBoobyTrapBody = [];
+    private static readonly List<byte> BoobyTrapBody = [];
+    private static readonly Dictionary<byte, byte> KillerOfBoobyTrapBody = [];
 
     public static void SetupCustomOption()
     {
@@ -33,13 +37,13 @@ internal class Trapster : RoleBase
 
     public override void Init()
     {
-        BoobyTrapBody = [];
-        KillerOfBoobyTrapBody = [];
-        On = false;
+        BoobyTrapBody.Clear();
+        KillerOfBoobyTrapBody.Clear();
+        Playerids.Clear();
     }
     public override void Add(byte playerId)
     {
-        On = true;
+        Playerids.Clear();
     }
 
     public override void SetKillCooldown(byte id) => Main.AllPlayerKillCooldown[id] = TrapsterKillCooldown.GetFloat();

--- a/Roles/Impostor/Trickster.cs
+++ b/Roles/Impostor/Trickster.cs
@@ -1,11 +1,17 @@
-﻿namespace TOHE.Roles.Impostor;
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace TOHE.Roles.Impostor;
 
 internal class Trickster : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 4800;
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> PlayerIds = [];
+    public static bool HasEnabled => PlayerIds.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Impostor;
+    //==================================================================\\
 
     public static void SetupCustomOption()
     {
@@ -13,10 +19,10 @@ internal class Trickster : RoleBase
     }
     public override void Init()
     {
-        On = false;
+        PlayerIds.Clear();
     }
     public override void Add(byte playerId)
     {
-        On = true;
+        PlayerIds.Add(playerId);
     }
 }

--- a/Roles/Impostor/Twister.cs
+++ b/Roles/Impostor/Twister.cs
@@ -10,10 +10,13 @@ namespace TOHE.Roles.Impostor;
 
 internal class Twister : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 5700;
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> PlayerIds = [];
+    public static bool HasEnabled => PlayerIds.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Shapeshifter;
+    //==================================================================\\
 
     private static OptionItem ShapeshiftCooldown;
     private static OptionItem ShapeshiftDuration;
@@ -32,12 +35,12 @@ internal class Twister : RoleBase
     }
     public override void Init()
     {
-        On = false;
+        PlayerIds.Clear();
         changePositionPlayers = [];
     }
     public override void Add(byte playerId)
     {
-        On = true;
+        PlayerIds.Add(playerId);
     }
 
     public override void ApplyGameOptions(IGameOptions opt, byte playerId)

--- a/Roles/Impostor/Underdog.cs
+++ b/Roles/Impostor/Underdog.cs
@@ -1,11 +1,17 @@
-﻿namespace TOHE.Roles.Impostor;
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace TOHE.Roles.Impostor;
 
 internal class Underdog : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 2700;
-    public static bool On;
-    public override bool IsEnable => On;
+    private static readonly HashSet<byte> PlayerIds = [];
+    public static bool HasEnabled => PlayerIds.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Impostor;
+    //==================================================================\\
 
     private static OptionItem UnderdogMaximumPlayersNeededToKill;
     private static OptionItem UnderdogKillCooldown;
@@ -22,11 +28,11 @@ internal class Underdog : RoleBase
     }
     public override void Init()
     {
-        On = false;
+        PlayerIds.Clear();
     }
     public override void Add(byte playerId)
     {
-        On = true;
+        PlayerIds.Add(playerId);
     }
 
     public override bool CanUseKillButton(PlayerControl pc) => Main.AllAlivePlayerControls.Length <= UnderdogMaximumPlayersNeededToKill.GetInt();

--- a/Roles/Impostor/Undertaker.cs
+++ b/Roles/Impostor/Undertaker.cs
@@ -119,7 +119,7 @@ internal class Undertaker : RoleBase
             target.RpcTeleport(MarkedLocation[killer.PlayerId]);
             
             target.SetRealKiller(killer);
-            target.RpcMurderPlayerV3(target);
+            target.RpcMurderPlayer(target);
 
             killer.SetKillCooldown();
             MarkedLocation[killer.PlayerId] = ExtendedPlayerControl.GetBlackRoomPosition();

--- a/Roles/Impostor/Vampire.cs
+++ b/Roles/Impostor/Vampire.cs
@@ -124,7 +124,7 @@ internal class Vampire : RoleBase
         {
             Main.PlayerStates[target.PlayerId].deathReason = PlayerState.DeathReason.Bite;
             target.SetRealKiller(vampire);
-            target.RpcMurderPlayerV3(target);
+            target.RpcMurderPlayer(target);
 
             Logger.Info($"{target.name} self-kill while being bitten by Vampire.", "Vampire");
             if (!isButton && vampire.IsAlive())

--- a/Roles/Impostor/Visionary.cs
+++ b/Roles/Impostor/Visionary.cs
@@ -33,14 +33,14 @@ internal class Visionary : RoleBase
 
         foreach (var SubRole in target.GetCustomSubRoles())
         {
-            if (SubRole.Is(CustomRoles.Charmed)
-                || SubRole.Is(CustomRoles.Infected)
-                || SubRole.Is(CustomRoles.Contagious)
-                || SubRole.Is(CustomRoles.Egoist)
-                || SubRole.Is(CustomRoles.Recruit)
-                || SubRole.Is(CustomRoles.Soulless)
-                || SubRole.Is(CustomRoles.Refugee)
-                || SubRole.Is(CustomRoles.Admired))
+            if (SubRole is CustomRoles.Charmed
+                or CustomRoles.Infected
+                or CustomRoles.Contagious
+                or CustomRoles.Egoist
+                or CustomRoles.Recruit
+                or CustomRoles.Soulless
+                or CustomRoles.Refugee
+                or CustomRoles.Admired)
                 return Main.roleColors[CustomRoles.Knight];
         }
 

--- a/Roles/Impostor/Warlock.cs
+++ b/Roles/Impostor/Warlock.cs
@@ -120,7 +120,7 @@ internal class Warlock : RoleBase
                     if (cp.RpcCheckAndMurder(targetw, true))
                     {
                         targetw.SetRealKiller(shapeshifter);
-                        cp.RpcMurderPlayerV3(targetw);
+                        cp.RpcMurderPlayer(targetw);
                         shapeshifter.RpcGuardAndKill(shapeshifter);
                         Logger.Info($"{targetw.GetNameWithRole()} was killed", "Warlock");
                         shapeshifter.Notify(Translator.GetString("WarlockControlKill"));

--- a/Roles/Impostor/Wildling.cs
+++ b/Roles/Impostor/Wildling.cs
@@ -52,7 +52,7 @@ internal class Wildling : RoleBase
         writer.Write(TimeStamp[playerId].ToString());
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         byte PlayerId = reader.ReadByte();
         string Time = reader.ReadString();

--- a/Roles/Impostor/Witch.cs
+++ b/Roles/Impostor/Witch.cs
@@ -11,14 +11,16 @@ namespace TOHE.Roles.Impostor;
 
 internal class Witch : RoleBase
 {
+    //===========================SETUP================================\\
     private const int Id = 2500;
-    public static bool On;
-    public override bool IsEnable => On;
+    private static HashSet<byte> playerIdList = [];
+    public static bool HasEnabled => playerIdList.Any();
+    public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Impostor;
+    //==================================================================\\
 
     public static OptionItem ModeSwitchActionOpt;
 
-    private static List<byte> playerIdList = [];
     private static Dictionary<byte, bool> SpellMode = [];
     private static Dictionary<byte, List<byte>> SpelledPlayer = [];
 
@@ -38,10 +40,9 @@ internal class Witch : RoleBase
     }
     public override void Init()
     {
-        playerIdList = [];
-        SpellMode = [];
-        SpelledPlayer = [];
-        On = false;
+        playerIdList.Clear();
+        SpellMode.Clear();
+        SpelledPlayer.Clear();
     }
     public override void Add(byte playerId)
     {
@@ -49,7 +50,6 @@ internal class Witch : RoleBase
         SpellMode.Add(playerId, false);
         SpelledPlayer.Add(playerId, []);
         NowSwitchTrigger = (SwitchTrigger)ModeSwitchActionOpt.GetValue();
-        On = true;
 
         var pc = Utils.GetPlayerById(playerId);
         pc.AddDoubleTrigger();
@@ -163,7 +163,7 @@ internal class Witch : RoleBase
     }
     public static void OnCheckForEndVoting(PlayerState.DeathReason deathReason, params byte[] exileIds)
     {
-        if (!On || deathReason != PlayerState.DeathReason.Vote) return;
+        if (!HasEnabled || deathReason != PlayerState.DeathReason.Vote) return;
 
         foreach (var id in exileIds)
         {

--- a/Roles/Neutral/Agitater.cs
+++ b/Roles/Neutral/Agitater.cs
@@ -82,7 +82,7 @@ internal class Agitater : RoleBase
         if (AgitaterAutoReportBait.GetBool() && target.Is(CustomRoles.Bait)) return true;
         if (target.Is(CustomRoles.Pestilence))
         {
-            target.RpcMurderPlayerV3(killer);
+            target.RpcMurderPlayer(killer);
             ResetBomb();
             return false;
         }
@@ -106,7 +106,7 @@ internal class Agitater : RoleBase
                 {
                     Main.PlayerStates[CurrentBombedPlayer].deathReason = PlayerState.DeathReason.Bombed;
                     pc.SetRealKiller(Utils.GetPlayerById(playerIdList[0]));
-                    pc.RpcMurderPlayerV3(pc);
+                    pc.RpcMurderPlayer(pc);
                     Logger.Info($"{killer.GetNameWithRole()}  bombed {pc.GetNameWithRole()} bomb cd complete", "Agitater");
                     ResetBomb();
                 }
@@ -179,7 +179,7 @@ internal class Agitater : RoleBase
 
         if (target.Is(CustomRoles.Pestilence))
         {
-            target.RpcMurderPlayerV3(player);
+            target.RpcMurderPlayer(player);
             ResetBomb();
             return;
         }

--- a/Roles/Neutral/Agitater.cs
+++ b/Roles/Neutral/Agitater.cs
@@ -159,7 +159,8 @@ internal class Agitater : RoleBase
                 var min = targetDistance.OrderBy(c => c.Value).FirstOrDefault();
                 var target = Utils.GetPlayerById(min.Key);
                 var KillRange = GameOptionsData.KillDistances[Mathf.Clamp(GameOptionsManager.Instance.currentNormalGameOptions.KillDistance, 0, 2)];
-                if (min.Value <= KillRange && !player.inVent && !target.inVent && player.RpcCheckAndMurder(target, true))
+                if (min.Value <= KillRange && !player.inVent && !target.inVent 
+                    && player.RpcCheckAndMurder(target, true) && player.CheckForInvalidMurdering(target))
                 {
                     PassBomb(player, target);
                 }

--- a/Roles/Neutral/Agitater.cs
+++ b/Roles/Neutral/Agitater.cs
@@ -159,7 +159,7 @@ internal class Agitater : RoleBase
                 var min = targetDistance.OrderBy(c => c.Value).FirstOrDefault();
                 var target = Utils.GetPlayerById(min.Key);
                 var KillRange = GameOptionsData.KillDistances[Mathf.Clamp(GameOptionsManager.Instance.currentNormalGameOptions.KillDistance, 0, 2)];
-                if (min.Value <= KillRange && !player.inVent && !target.inVent)
+                if (min.Value <= KillRange && !player.inVent && !target.inVent && player.RpcCheckAndMurder(target, true))
                 {
                     PassBomb(player, target);
                 }

--- a/Roles/Neutral/Agitater.cs
+++ b/Roles/Neutral/Agitater.cs
@@ -159,8 +159,7 @@ internal class Agitater : RoleBase
                 var min = targetDistance.OrderBy(c => c.Value).FirstOrDefault();
                 var target = Utils.GetPlayerById(min.Key);
                 var KillRange = GameOptionsData.KillDistances[Mathf.Clamp(GameOptionsManager.Instance.currentNormalGameOptions.KillDistance, 0, 2)];
-                if (min.Value <= KillRange && !player.inVent && !target.inVent 
-                    && player.RpcCheckAndMurder(target, true) && player.CheckForInvalidMurdering(target))
+                if (min.Value <= KillRange && !player.inVent && !target.inVent && player.RpcCheckAndMurder(target, true))
                 {
                     PassBomb(player, target);
                 }

--- a/Roles/Neutral/Agitater.cs
+++ b/Roles/Neutral/Agitater.cs
@@ -205,7 +205,7 @@ internal class Agitater : RoleBase
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
 
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         CurrentBombedPlayer = reader.ReadByte();
         LastBombedPlayer = reader.ReadByte();

--- a/Roles/Neutral/Arsonist.cs
+++ b/Roles/Neutral/Arsonist.cs
@@ -222,7 +222,7 @@ internal class Arsonist : RoleBase
                     {
                         pc.SetRealKiller(__instance.myPlayer);
                         Main.PlayerStates[pc.PlayerId].deathReason = PlayerState.DeathReason.Torched;
-                        pc.RpcMurderPlayerV3(pc);
+                        pc.RpcMurderPlayer(pc);
                     }
                 }
                 foreach (var pc in Main.AllPlayerControls) 
@@ -246,7 +246,7 @@ internal class Arsonist : RoleBase
                         if (!IsDousedPlayer(__instance.myPlayer, pc)) continue;
                         pc.KillFlash();
                         Main.PlayerStates[pc.PlayerId].deathReason = PlayerState.DeathReason.Torched;
-                        pc.RpcMurderPlayerV3(pc);
+                        pc.RpcMurderPlayer(pc);
                         pc.SetRealKiller(__instance.myPlayer);
                     }
                     if (Main.AllAlivePlayerControls.Length == 1)

--- a/Roles/Neutral/Bandit.cs
+++ b/Roles/Neutral/Bandit.cs
@@ -83,7 +83,7 @@ internal class Bandit : RoleBase
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
 
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         byte PlayerId = reader.ReadByte();
         int Limit = reader.ReadInt32();

--- a/Roles/Neutral/BloodKnight.cs
+++ b/Roles/Neutral/BloodKnight.cs
@@ -57,7 +57,7 @@ internal class BloodKnight : RoleBase
         writer.Write(TimeStamp[playerId].ToString());
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         byte PlayerId = reader.ReadByte();
         string Time = reader.ReadString();

--- a/Roles/Neutral/Collector.cs
+++ b/Roles/Neutral/Collector.cs
@@ -49,7 +49,7 @@ internal class Collector : RoleBase
         writer.Write(CollectVote[playerId]);
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         byte PlayerId = reader.ReadByte();
         int Num = reader.ReadInt32();

--- a/Roles/Neutral/Cultist.cs
+++ b/Roles/Neutral/Cultist.cs
@@ -72,7 +72,7 @@ internal class Cultist : RoleBase
         writer.Write(CharmLimit);
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         CharmLimit = reader.ReadInt32();
     }

--- a/Roles/Neutral/Demon.cs
+++ b/Roles/Neutral/Demon.cs
@@ -96,7 +96,7 @@ internal class Demon : RoleBase
         if (PlayerHealth[target.PlayerId] - Damage.GetInt() < 1)
         {
             PlayerHealth.Remove(target.PlayerId);
-            killer.RpcMurderPlayerV3(target);
+            killer.RpcMurderPlayer(target);
             Utils.NotifyRoles(SpecifySeer: killer);
             return false;
         }

--- a/Roles/Neutral/Demon.cs
+++ b/Roles/Neutral/Demon.cs
@@ -79,7 +79,7 @@ internal class Demon : RoleBase
             writer.Write(PlayerHealth[playerId]);
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         byte PlayerId = reader.ReadByte();
         int Health = reader.ReadInt32();

--- a/Roles/Neutral/Doomsayer.cs
+++ b/Roles/Neutral/Doomsayer.cs
@@ -90,7 +90,7 @@ internal class Doomsayer : RoleBase
         writer.Write(player.PlayerId);
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         byte DoomsayerId = reader.ReadByte();
         GuessingToWin[DoomsayerId]++;

--- a/Roles/Neutral/Doppelganger.cs
+++ b/Roles/Neutral/Doppelganger.cs
@@ -64,7 +64,7 @@ internal class Doppelganger : RoleBase
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
 
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         byte PlayerId = reader.ReadByte();
         int Limit = reader.ReadInt32();

--- a/Roles/Neutral/Hater.cs
+++ b/Roles/Neutral/Hater.cs
@@ -96,12 +96,12 @@ internal class Hater : RoleBase
         {
             target.SetRealKiller(killer);
             Main.PlayerStates[target.PlayerId].deathReason = PlayerState.DeathReason.Misfire;
-            killer.RpcMurderPlayerV3(target); // Murder the target only if the setting is on and the target can be killed
+            killer.RpcMurderPlayer(target); // Murder the target only if the setting is on and the target can be killed
 
         }
 
         Main.PlayerStates[killer.PlayerId].deathReason = PlayerState.DeathReason.Sacrifice;
-        killer.RpcMurderPlayerV3(killer);
+        killer.RpcMurderPlayer(killer);
         
         Logger.Info($"{killer.GetRealName()} killed incorrect target => misfire", "FFF");
         return false;

--- a/Roles/Neutral/Huntsman.cs
+++ b/Roles/Neutral/Huntsman.cs
@@ -81,7 +81,7 @@ internal class Huntsman : RoleBase
         }
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         bool isSetTarget = reader.ReadBoolean();
         if (!isSetTarget)

--- a/Roles/Neutral/Imitator.cs
+++ b/Roles/Neutral/Imitator.cs
@@ -60,7 +60,7 @@ internal class Imitator : RoleBase
         writer.Write(RememberLimit[playerId]);
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         byte playerId = reader.ReadByte();
         int Limit = reader.ReadInt32();

--- a/Roles/Neutral/Imitator.cs
+++ b/Roles/Neutral/Imitator.cs
@@ -82,12 +82,12 @@ internal class Imitator : RoleBase
 
         var role = target.GetCustomRole();
 
-        if (role.Is(CustomRoles.Jackal)
-            || role.Is(CustomRoles.HexMaster)
-            || role.Is(CustomRoles.Poisoner) 
-            || role.Is(CustomRoles.Juggernaut) 
-            || role.Is(CustomRoles.BloodKnight)
-            || role.Is(CustomRoles.Sheriff))
+        if (role is CustomRoles.Jackal
+            or CustomRoles.HexMaster
+            or CustomRoles.Poisoner
+            or CustomRoles.Juggernaut 
+            or CustomRoles.BloodKnight
+            or CustomRoles.Sheriff)
         {
             RememberLimit[killer.PlayerId]--;
             SendRPC(killer.PlayerId);

--- a/Roles/Neutral/Infectious.cs
+++ b/Roles/Neutral/Infectious.cs
@@ -99,7 +99,7 @@ internal class Infectious : RoleBase
 
         if (!CanBeBitten(target) && !target.Is(CustomRoles.Infected))
         {
-            killer.RpcMurderPlayerV3(target);
+            killer.RpcMurderPlayer(target);
         }
 
         if (BiteLimit < 0)
@@ -130,7 +130,7 @@ internal class Infectious : RoleBase
             //Logger.Warn("VALUE OF CHECK IS")
             if (check)
             {
-                killer.RpcMurderPlayerV3(target);
+                killer.RpcMurderPlayer(target);
                 return true;
             }
             else return false;
@@ -148,7 +148,7 @@ internal class Infectious : RoleBase
             foreach (var alivePlayer in Main.AllAlivePlayerControls.Where(pc => pc.Is(CustomRoles.Infected)))
             {
                 Main.PlayerStates[alivePlayer.PlayerId].deathReason = PlayerState.DeathReason.Infected;
-                alivePlayer.RpcMurderPlayerV3(alivePlayer);
+                alivePlayer.RpcMurderPlayer(alivePlayer);
             }
         }
     }

--- a/Roles/Neutral/Innocent.cs
+++ b/Roles/Neutral/Innocent.cs
@@ -34,7 +34,7 @@ internal class Innocent : RoleBase
         PlayerIds.Add(playerId);
     }
     public override bool CanUseKillButton(PlayerControl pc) => true;
-    public override bool OnCheckMurderAsKiller(PlayerControl killer, PlayerControl target)
+    public override bool ForcedCheckMurderAsKiller(PlayerControl killer, PlayerControl target)
     {
         target.RpcMurderPlayer(killer);
         return false;

--- a/Roles/Neutral/Innocent.cs
+++ b/Roles/Neutral/Innocent.cs
@@ -36,7 +36,7 @@ internal class Innocent : RoleBase
     public override bool CanUseKillButton(PlayerControl pc) => true;
     public override bool OnCheckMurderAsKiller(PlayerControl killer, PlayerControl target)
     {
-        target.RpcMurderPlayerV3(killer);
+        target.RpcMurderPlayer(killer);
         return false;
     }
 

--- a/Roles/Neutral/Jackal.cs
+++ b/Roles/Neutral/Jackal.cs
@@ -114,7 +114,7 @@ internal class Jackal : RoleBase
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
 
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         byte PlayerId = reader.ReadByte();
         int Limit = reader.ReadInt32();

--- a/Roles/Neutral/Jinx.cs
+++ b/Roles/Neutral/Jinx.cs
@@ -78,8 +78,8 @@ internal class Jinx : RoleBase
        
         JinxSpellCount[target.PlayerId] -= 1;
         SendRPCJinxSpellCount(target.PlayerId);
-        
-        if (killAttacker.GetBool())
+
+        if (killAttacker.GetBool() && target.RpcCheckAndMurder(killer, true))
         {
             killer.SetRealKiller(target);
             Logger.Info($"{target.GetNameWithRole()} : {JinxSpellCount[target.PlayerId]}回目", "Jinx");

--- a/Roles/Neutral/Jinx.cs
+++ b/Roles/Neutral/Jinx.cs
@@ -84,7 +84,7 @@ internal class Jinx : RoleBase
             killer.SetRealKiller(target);
             Logger.Info($"{target.GetNameWithRole()} : {JinxSpellCount[target.PlayerId]}回目", "Jinx");
             Main.PlayerStates[killer.PlayerId].deathReason = PlayerState.DeathReason.Jinx;
-            killer.RpcMurderPlayerV3(killer);
+            killer.RpcMurderPlayer(killer);
         }
         return false;
     }

--- a/Roles/Neutral/Lawyer.cs
+++ b/Roles/Neutral/Lawyer.cs
@@ -130,7 +130,7 @@ internal class Lawyer : RoleBase
 
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         bool SetTarget = reader.ReadBoolean();
         if (SetTarget)

--- a/Roles/Neutral/Necromancer.cs
+++ b/Roles/Neutral/Necromancer.cs
@@ -90,7 +90,7 @@ internal class Necromancer : RoleBase
         }
         if (seconds <= 0 || GameStates.IsMeeting && player.IsAlive()) 
         { 
-            player.RpcMurderPlayerV3(player); 
+            player.RpcMurderPlayer(player); 
             player.SetRealKiller(killer);
             Killer = null; 
             return; 
@@ -116,7 +116,7 @@ internal class Necromancer : RoleBase
         }
         else
         {
-            killer.RpcMurderPlayerV3(killer);
+            killer.RpcMurderPlayer(killer);
             return false;
         }
     }

--- a/Roles/Neutral/Opportunist.cs
+++ b/Roles/Neutral/Opportunist.cs
@@ -12,6 +12,7 @@ internal class Opportunist : RoleBase
     public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Crewmate;
     //==================================================================\\
+    public override bool HasTasks(GameData.PlayerInfo player, CustomRoles role, bool ForRecompute) => !ForRecompute;
 
     private static OptionItem OppoImmuneToAttacksWhenTasksDone;
 

--- a/Roles/Neutral/Pelican.cs
+++ b/Roles/Neutral/Pelican.cs
@@ -72,7 +72,7 @@ internal class Pelican : RoleBase
         }
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         byte playerId = reader.ReadByte();
         if (playerId == byte.MaxValue)

--- a/Roles/Neutral/Phantom.cs
+++ b/Roles/Neutral/Phantom.cs
@@ -14,6 +14,7 @@ internal class Phantom : RoleBase
     public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => PhantomCanVent.GetBool() ? CustomRoles.Engineer : CustomRoles.Crewmate;
     //==================================================================\\
+    public override bool HasTasks(GameData.PlayerInfo player, CustomRoles role, bool ForRecompute) => !ForRecompute;
 
     private static OptionItem PhantomCanVent;
     public static OptionItem PhantomSnatchesWin;

--- a/Roles/Neutral/Pirate.cs
+++ b/Roles/Neutral/Pirate.cs
@@ -91,7 +91,7 @@ internal class Pirate : RoleBase
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
 
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         int operate = reader.ReadInt32();
         byte target = reader.ReadByte();

--- a/Roles/Neutral/Pixie.cs
+++ b/Roles/Neutral/Pixie.cs
@@ -93,7 +93,7 @@ internal class Pixie : RoleBase
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
 
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         byte pixieId = reader.ReadByte();
         bool operate = reader.ReadBoolean();

--- a/Roles/Neutral/PlagueBearer.cs
+++ b/Roles/Neutral/PlagueBearer.cs
@@ -99,7 +99,7 @@ internal class PlagueBearer : RoleBase
         }
         return false;
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         byte PlagueBearerId = reader.ReadByte();
         byte PlaguedId = reader.ReadByte();

--- a/Roles/Neutral/PlagueBearer.cs
+++ b/Roles/Neutral/PlagueBearer.cs
@@ -138,15 +138,14 @@ internal class PlagueBearer : RoleBase
         var (countItem1, countItem2) = PlaguedPlayerCount(player.PlayerId);
         return countItem1 >= countItem2;
     }
-
-    public override bool OnCheckMurderAsKiller(PlayerControl killer, PlayerControl target)
+    public override bool ForcedCheckMurderAsKiller(PlayerControl killer, PlayerControl target)
     {
         if (killer.GetCustomRole() == CustomRoles.Pestilence) return true;
 
         if (IsPlagued(killer.PlayerId, target.PlayerId))
         {
             killer.Notify(GetString("PlagueBearerAlreadyPlagued"));
-            return false;
+            return true;
         }
         PlaguedList[killer.PlayerId].Add(target.PlayerId);
         SendRPC(killer, target);
@@ -156,7 +155,11 @@ internal class PlagueBearer : RoleBase
         killer.SetKillCooldown();
 
         Logger.Info($"kill cooldown {PlagueBearerCD[killer.PlayerId]}", "PlagueBearer");
-        return false;
+        return true;
+    }
+    public override bool OnCheckMurderAsKiller(PlayerControl killer, PlayerControl target)
+    {
+        return killer.Is(CustomRoles.Pestilence);
     }
 
     public override string GetProgressText(byte playerId, bool comms)

--- a/Roles/Neutral/PlagueBearer.cs
+++ b/Roles/Neutral/PlagueBearer.cs
@@ -181,7 +181,7 @@ internal class PlagueBearer : RoleBase
         if (!PestilenceList.Contains(target.PlayerId)) return false;
 
         killer.SetRealKiller(target);
-        target.RpcMurderPlayerV3(killer);
+        target.RpcMurderPlayer(killer);
         return true;
     }
     public override void SetAbilityButtonText(HudManager hud, byte playerId)

--- a/Roles/Neutral/PlagueDoctor.cs
+++ b/Roles/Neutral/PlagueDoctor.cs
@@ -126,7 +126,7 @@ internal class PlagueDoctor : RoleBase
         writer.Write(rate);
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         var firstInfect = reader.ReadBoolean();
         var targetId = reader.ReadByte();

--- a/Roles/Neutral/PlagueDoctor.cs
+++ b/Roles/Neutral/PlagueDoctor.cs
@@ -294,7 +294,7 @@ internal class PlagueDoctor : RoleBase
             {
                 if (player.Is(CustomRoles.PlagueDoctor)) continue;
                 Main.PlayerStates[player.PlayerId].deathReason = PlayerState.DeathReason.Infected;
-                player.RpcMurderPlayerV3(player);
+                player.RpcMurderPlayer(player);
             }
             CustomWinnerHolder.ResetAndSetWinner(CustomWinner.PlagueDoctor);
             foreach (var plagueDoctor in Main.AllPlayerControls.Where(p => p.Is(CustomRoles.PlagueDoctor)).ToArray())

--- a/Roles/Neutral/Poisoner.cs
+++ b/Roles/Neutral/Poisoner.cs
@@ -113,7 +113,7 @@ internal class Poisoner : RoleBase
             Main.PlayerStates[target.PlayerId].deathReason = PlayerState.DeathReason.Poison;
             target.SetRealKiller(poisoner);
             target.RpcMurderPlayerV3(target);
-            Logger.Info($"Poisonerに噛まれている{target.name}を自爆させました。", "Poisoner");
+            Logger.Info($"{target.GetRealName()} Died by Poison", "Poisoner");
             if (!isButton && poisoner.IsAlive())
             {
                 RPC.PlaySoundRPC(poisoner.PlayerId, Sounds.KillSound);
@@ -125,7 +125,7 @@ internal class Poisoner : RoleBase
         }
         else
         {
-            Logger.Info("Poisonerに噛まれている" + target.name + "はすでに死んでいました。", "Poisoner");
+            Logger.Info($"{target.GetRealName()} was in an unkillable state, poison was canceled", "Poisoner");
         }
     }
     public override void OnReportDeadBody(PlayerControl sans, PlayerControl bateman)

--- a/Roles/Neutral/Poisoner.cs
+++ b/Roles/Neutral/Poisoner.cs
@@ -11,7 +11,7 @@ namespace TOHE.Roles.Neutral;
 
 internal class Poisoner : RoleBase
 {
-    private class PoisonedInfo(byte poisonerId, float killTimer) // Mf's before Dictionary(item1, item2) was discovered 💀
+    private class PoisonedInfo(byte poisonerId, float killTimer) 
     {
         public byte PoisonerId = poisonerId;
         public float KillTimer = killTimer;

--- a/Roles/Neutral/Poisoner.cs
+++ b/Roles/Neutral/Poisoner.cs
@@ -112,7 +112,7 @@ internal class Poisoner : RoleBase
         {
             Main.PlayerStates[target.PlayerId].deathReason = PlayerState.DeathReason.Poison;
             target.SetRealKiller(poisoner);
-            target.RpcMurderPlayerV3(target);
+            target.RpcMurderPlayer(target);
             Logger.Info($"{target.GetRealName()} Died by Poison", "Poisoner");
             if (!isButton && poisoner.IsAlive())
             {

--- a/Roles/Neutral/PotionMaster.cs
+++ b/Roles/Neutral/PotionMaster.cs
@@ -64,7 +64,7 @@ internal class PotionMaster : RoleBase
         writer.Write(targetId);
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         byte playerId = reader.ReadByte();
         {

--- a/Roles/Neutral/Provocateur.cs
+++ b/Roles/Neutral/Provocateur.cs
@@ -46,8 +46,8 @@ internal class Provocateur : RoleBase
             return false;
         }
         Main.PlayerStates[target.PlayerId].deathReason = PlayerState.DeathReason.PissedOff;
-        killer.RpcMurderPlayerV3(target);
-        killer.RpcMurderPlayerV3(killer);
+        killer.RpcMurderPlayer(target);
+        killer.RpcMurderPlayer(killer);
         killer.SetRealKiller(target);
         Provoked.TryAdd(killer.PlayerId, target.PlayerId);
         return false;

--- a/Roles/Neutral/Pursuer.cs
+++ b/Roles/Neutral/Pursuer.cs
@@ -57,7 +57,7 @@ internal class Pursuer : RoleBase
         writer.Write(SeelLimit[playerId]);
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         byte PlayerId = reader.ReadByte();
         int Limit = reader.ReadInt32();

--- a/Roles/Neutral/Pursuer.cs
+++ b/Roles/Neutral/Pursuer.cs
@@ -128,7 +128,7 @@ internal class Pursuer : RoleBase
         
         Main.PlayerStates[target.PlayerId].deathReason = PlayerState.DeathReason.Misfire;
         target.SetRealKiller(killer);
-        target.RpcMurderPlayerV3(target);
+        target.RpcMurderPlayer(target);
         
         Logger.Info($"赝品商 {pc.GetRealName()} 的客户 {target.GetRealName()} 因使用赝品走火自杀", "Pursuer");
         return true;

--- a/Roles/Neutral/Quizmaster.cs
+++ b/Roles/Neutral/Quizmaster.cs
@@ -106,7 +106,7 @@ internal class Quizmaster : RoleBase
         writer.Write(targetId);
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         byte targetId = reader.ReadByte();
 

--- a/Roles/Neutral/Quizmaster.cs
+++ b/Roles/Neutral/Quizmaster.cs
@@ -136,6 +136,7 @@ internal class Quizmaster : RoleBase
 
     public override bool OnCheckMurderAsKiller(PlayerControl killer, PlayerControl target)
     {
+        if (!killer.RpcCheckAndMurder(target, true)) return false;
         if (AlreadyMarked == false)
         {
             //allowedVenting = false;

--- a/Roles/Neutral/Revolutionist.cs
+++ b/Roles/Neutral/Revolutionist.cs
@@ -230,7 +230,7 @@ internal class Revolutionist : RoleBase
                     {
                         rv_target.SetRealKiller(player);
                         Main.PlayerStates[rvTargetId].deathReason = PlayerState.DeathReason.Sacrifice;
-                        player.RpcMurderPlayerV3(rv_target);
+                        player.RpcMurderPlayer(rv_target);
                         Main.PlayerStates[rvTargetId].SetDead();
                         Logger.Info($"Revolutionist: {player.GetNameWithRole()} killed by {rv_target.GetNameWithRole()}", "Revolutionist");
                     }
@@ -278,13 +278,13 @@ internal class Revolutionist : RoleBase
                         {
                             pc.Data.IsDead = true;
                             Main.PlayerStates[pc.PlayerId].deathReason = PlayerState.DeathReason.Sacrifice;
-                            pc.RpcMurderPlayerV3(pc);
+                            pc.RpcMurderPlayer(pc);
                             Main.PlayerStates[pc.PlayerId].SetDead();
                             NotifyRoles(SpecifySeer: pc);
                         }
                         player.Data.IsDead = true;
                         Main.PlayerStates[playerId].deathReason = PlayerState.DeathReason.Sacrifice;
-                        player.RpcMurderPlayerV3(player);
+                        player.RpcMurderPlayer(player);
                         Main.PlayerStates[playerId].SetDead();
                     }
                     else

--- a/Roles/Neutral/Romantic.cs
+++ b/Roles/Neutral/Romantic.cs
@@ -87,7 +87,7 @@ internal class Romantic : RoleBase
         writer.Write(BetPlayer.TryGetValue(playerId, out var player) ? player : byte.MaxValue);
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         byte PlayerId = reader.ReadByte();
         int Times = reader.ReadInt32();
@@ -337,7 +337,7 @@ internal class VengefulRomantic : RoleBase
         writer.Write(VengefulTarget.TryGetValue(playerId, out var player) ? player : byte.MaxValue);
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         byte PlayerId = reader.ReadByte();
         byte Target = reader.ReadByte();

--- a/Roles/Neutral/Romantic.cs
+++ b/Roles/Neutral/Romantic.cs
@@ -317,7 +317,7 @@ internal class VengefulRomantic : RoleBase
         }
         else
         {
-            killer.RpcMurderPlayerV3(killer);
+            killer.RpcMurderPlayer(killer);
             Main.PlayerStates[killer.PlayerId].deathReason = PlayerState.DeathReason.Misfire;
             return false;
         }

--- a/Roles/Neutral/SchrodingersCat.cs
+++ b/Roles/Neutral/SchrodingersCat.cs
@@ -41,7 +41,7 @@ internal class SchrodingersCat : RoleBase
         writer.Write(teammate[catID]);
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         byte catID = reader.ReadByte();
         byte teammateID = reader.ReadByte();

--- a/Roles/Neutral/Seeker.cs
+++ b/Roles/Neutral/Seeker.cs
@@ -97,7 +97,7 @@ internal class Seeker : RoleBase
 
         Targets[seekerId] = targetId;
     }
-    public override bool OnCheckMurderAsKiller(PlayerControl killer, PlayerControl target)
+    public override bool ForcedCheckMurderAsKiller(PlayerControl killer, PlayerControl target)
     {
         if (GetTarget(killer) == target.PlayerId)
         {//if the target is correct

--- a/Roles/Neutral/Seeker.cs
+++ b/Roles/Neutral/Seeker.cs
@@ -79,7 +79,7 @@ internal class Seeker : RoleBase
         }
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         bool setTarget = reader.ReadBoolean();
         byte seekerId = reader.ReadByte();

--- a/Roles/Neutral/Shroud.cs
+++ b/Roles/Neutral/Shroud.cs
@@ -137,7 +137,7 @@ internal class Shroud : RoleBase
                         RPC.PlaySoundRPC(shroudId, Sounds.KillSound);
                         target.SetRealKiller(Utils.GetPlayerById(shroudId));
                         Main.PlayerStates[target.PlayerId].deathReason = PlayerState.DeathReason.Shrouded;
-                        shroud.RpcMurderPlayerV3(target);
+                        shroud.RpcMurderPlayer(target);
                         Utils.MarkEveryoneDirtySettings();
                         ShroudList.Remove(shroud.PlayerId);
                         SendRPC(byte.MaxValue, shroud.PlayerId, 2);
@@ -164,7 +164,7 @@ internal class Shroud : RoleBase
             if (shrouded == null) continue;
 
             Main.PlayerStates[shrouded.PlayerId].deathReason = PlayerState.DeathReason.Shrouded;
-            shrouded.RpcMurderPlayerV3(shrouded);
+            shrouded.RpcMurderPlayer(shrouded);
 
             ShroudList.Remove(shrouded.PlayerId);
             SendRPC(byte.MaxValue, shrouded.PlayerId, 2);

--- a/Roles/Neutral/Shroud.cs
+++ b/Roles/Neutral/Shroud.cs
@@ -58,7 +58,7 @@ internal class Shroud : RoleBase
         writer.Write(targetId);
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         var typeId = reader.ReadByte();
         var shroudId = reader.ReadByte();

--- a/Roles/Neutral/Solsticer.cs
+++ b/Roles/Neutral/Solsticer.cs
@@ -153,32 +153,6 @@ internal class Solsticer : RoleBase
         }
         return true; //should be patched before every others
     } //My idea is to encourage everyone to kill Solsticer and won't waste shoots on it, only resets cd.
-    public static bool OnCheckRpcMurderv3(PlayerControl killer, PlayerControl target)
-    {
-        if (!HasEnabled || !target.Is(CustomRoles.Solsticer)) return false;
-        if (!GameStates.IsMeeting)
-        {
-            if (target.PlayerId != killer.PlayerId)
-            {
-                killer.RpcTeleport(target.GetTruePosition());
-                killer.RpcGuardAndKill(target);
-                killer.SetKillCooldown(forceAnime: true);
-                killer.Notify(GetString("MurderSolsticer"));
-            }
-
-            target.RpcGuardAndKill();
-            patched = true;
-            ResetTasks(target);
-            target.MarkDirtySettings();
-
-            target.Notify(string.Format(GetString("SolsticerMurdered"), killer.GetRealName()));
-            if (SolsticerKnowKiller.GetBool())
-                MurderMessage = string.Format(GetString("SolsticerMurderMessage"), killer.GetRealName(), GetString(killer.GetCustomRole().ToString()));
-            else MurderMessage = "";
-        }
-        //Solsticer wont die anyway.
-        return true;
-    }
     public override void AfterMeetingTasks()
     {
         foreach (var pc in Main.AllAlivePlayerControls.Where(x => x.Is(CustomRoles.Solsticer)).ToArray())

--- a/Roles/Neutral/Solsticer.cs
+++ b/Roles/Neutral/Solsticer.cs
@@ -237,7 +237,7 @@ internal class Solsticer : RoleBase
         writer.Write(playerid);
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         Logger.Info("syncsolsticer", "solsticer");
         int AllCount = reader.ReadInt32();

--- a/Roles/Neutral/SoulCollector.cs
+++ b/Roles/Neutral/SoulCollector.cs
@@ -60,7 +60,7 @@ internal class SoulCollector : RoleBase
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
 
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         byte SoulCollectorId = reader.ReadByte();
         int Limit = reader.ReadInt32();

--- a/Roles/Neutral/Spiritcaller.cs
+++ b/Roles/Neutral/Spiritcaller.cs
@@ -86,7 +86,7 @@ internal class Spiritcaller : RoleBase
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
 
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         SpiritLimit = reader.ReadInt32();
     }

--- a/Roles/Neutral/Taskinator.cs
+++ b/Roles/Neutral/Taskinator.cs
@@ -139,7 +139,7 @@ internal class Taskinator : RoleBase
 
                     Main.PlayerStates[player.PlayerId].deathReason = PlayerState.DeathReason.Bombed;
                     player.SetRealKiller(taskinatorPC);
-                    player.RpcMurderPlayerV3(player);
+                    player.RpcMurderPlayer(player);
 
                     taskIndex[taskinatorId].Remove(task.Index);
                     SendRPC(taskinatorID : taskinatorId, taskIndex:task.Index, isKill : true);

--- a/Roles/Neutral/Taskinator.cs
+++ b/Roles/Neutral/Taskinator.cs
@@ -16,6 +16,7 @@ internal class Taskinator : RoleBase
     public override bool IsEnable => false;
     public override CustomRoles ThisRoleBase => CustomRoles.Crewmate;
     //==================================================================\\
+    public override bool HasTasks(GameData.PlayerInfo player, CustomRoles role, bool ForRecompute) => !ForRecompute;
 
     private static OptionItem TaskMarkPerRoundOpt;
 

--- a/Roles/Neutral/Taskinator.cs
+++ b/Roles/Neutral/Taskinator.cs
@@ -113,6 +113,7 @@ internal class Taskinator : RoleBase
         if (player == null) return;
         if (!player.IsAlive()) return;
         byte playerId = player.PlayerId;
+        var Taskinators = playerIdList.GetPlayerListByIds();
         if (player.Is(CustomRoles.Taskinator))
         {
             if (!TaskMarkPerRound.ContainsKey(playerId)) TaskMarkPerRound[playerId] = 0;
@@ -125,10 +126,10 @@ internal class Taskinator : RoleBase
             TaskMarkPerRound[playerId]++;
             if (!taskIndex.ContainsKey(playerId)) taskIndex[playerId] = [];
             taskIndex[playerId].Add(task.Index);
-            SendRPC(taskinatorID : playerId, taskIndex : task.Index);
+            SendRPC(taskinatorID: playerId, taskIndex: task.Index);
             player.Notify(GetString("TaskinatorBombPlanted"));
         }
-        else
+        else if (Taskinators.All(Inator => Inator.RpcCheckAndMurder(player, true)))
         {
             foreach (var taskinatorId in taskIndex.Keys)
             { 

--- a/Roles/Neutral/Taskinator.cs
+++ b/Roles/Neutral/Taskinator.cs
@@ -60,7 +60,7 @@ internal class Taskinator : RoleBase
         }
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         byte taskinatorID = reader.ReadByte();
         int taskInd = reader.ReadInt32();

--- a/Roles/Neutral/Terrorist.cs
+++ b/Roles/Neutral/Terrorist.cs
@@ -15,6 +15,7 @@ internal class Terrorist : RoleBase
     public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Engineer;
     //==================================================================\\
+    public override bool HasTasks(GameData.PlayerInfo player, CustomRoles role, bool ForRecompute) => !ForRecompute;
 
     public static OptionItem CanTerroristSuicideWin;
     public static OptionItem TerroristCanGuess;

--- a/Roles/Neutral/Terrorist.cs
+++ b/Roles/Neutral/Terrorist.cs
@@ -76,7 +76,7 @@ internal class Terrorist : RoleBase
                     pc.SetRealKiller(terrorist.Object);
                     Main.PlayerStates[pc.PlayerId].deathReason = PlayerState.DeathReason.Bombed;
                     Main.PlayerStates[pc.PlayerId].SetDead();
-                    pc.RpcMurderPlayerV3(pc);
+                    pc.RpcMurderPlayer(pc);
                 }
             }
             if (!CustomWinnerHolder.CheckForConvertedWinner(terrorist.PlayerId))

--- a/Roles/Neutral/Virus.cs
+++ b/Roles/Neutral/Virus.cs
@@ -97,7 +97,7 @@ internal class Virus : RoleBase
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
 
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         InfectLimit = reader.ReadInt32();
     }

--- a/Roles/Neutral/Werewolf.cs
+++ b/Roles/Neutral/Werewolf.cs
@@ -66,7 +66,7 @@ internal class Werewolf : RoleBase
                 {
                     Main.PlayerStates[player.PlayerId].deathReason = PlayerState.DeathReason.Mauled;
                     player.SetRealKiller(killer);
-                    player.RpcMurderPlayerV3(player);
+                    player.RpcMurderPlayer(player);
                 }
             }
         }, 0.1f, "Werewolf Maul Bug Fix");

--- a/Roles/Neutral/Workaholic.cs
+++ b/Roles/Neutral/Workaholic.cs
@@ -17,6 +17,7 @@ internal class Workaholic : RoleBase
     public override bool IsEnable => HasEnabled;
     public override CustomRoles ThisRoleBase => CustomRoles.Engineer;
     //==================================================================\\
+    public override bool HasTasks(GameData.PlayerInfo player, CustomRoles role, bool ForRecompute) => !ForRecompute;
 
     public static OptionItem WorkaholicCannotWinAtDeath;
     public static OptionItem WorkaholicVentCooldown;

--- a/Roles/Neutral/Workaholic.cs
+++ b/Roles/Neutral/Workaholic.cs
@@ -76,7 +76,7 @@ internal class Workaholic : RoleBase
                 Main.PlayerStates[pc.PlayerId].deathReason = pc.PlayerId == player.PlayerId ?
                     PlayerState.DeathReason.Overtired : PlayerState.DeathReason.Ashamed;
 
-                pc.RpcMurderPlayerV3(pc);
+                pc.RpcMurderPlayer(pc);
                 pc.SetRealKiller(player);
             }
         }

--- a/Roles/Neutral/Wraith.cs
+++ b/Roles/Neutral/Wraith.cs
@@ -67,7 +67,7 @@ internal class Wraith : RoleBase
         writer.Write((lastTime.TryGetValue(pc.PlayerId, out var y) ? y : -1).ToString());
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveRPC(MessageReader reader)
+    public override void ReceiveRPC(MessageReader reader, PlayerControl NaN)
     {
         InvisTime.Clear();
         lastTime.Clear();

--- a/main.cs
+++ b/main.cs
@@ -148,7 +148,6 @@ public class Main : BasePlugin
     public static readonly Dictionary<byte, float> AllPlayerSpeed = [];
     
     public static readonly Dictionary<CustomRoles, RoleBase> RoleClass = [];
-    public static readonly List<RoleBase> EnabledRoles = [];
 
     public static readonly Dictionary<byte, int> GuesserGuessed = [];
     public static readonly Dictionary<byte, long> AllKillers = [];

--- a/main.cs
+++ b/main.cs
@@ -148,6 +148,7 @@ public class Main : BasePlugin
     public static readonly Dictionary<byte, float> AllPlayerSpeed = [];
     
     public static readonly Dictionary<CustomRoles, RoleBase> RoleClass = [];
+    public static List<RoleBase> EnabledRoles => RoleClass.Values.Where(x => x.IsEnable).ToList();
 
     public static readonly Dictionary<byte, int> GuesserGuessed = [];
     public static readonly Dictionary<byte, long> AllKillers = [];

--- a/main.cs
+++ b/main.cs
@@ -148,6 +148,7 @@ public class Main : BasePlugin
     public static readonly Dictionary<byte, float> AllPlayerSpeed = [];
     
     public static readonly Dictionary<CustomRoles, RoleBase> RoleClass = [];
+    public static readonly List<RoleBase> EnabledRoles = [];
 
     public static readonly Dictionary<byte, int> GuesserGuessed = [];
     public static readonly Dictionary<byte, long> AllKillers = [];


### PR DESCRIPTION
did all the ones in syncroleskillreader as it was simple, and @NikoCat233 may do the rest.
Basically ready to merge, I'm just adding/changing stuff as I see fit rn


Did these points for all roles now.
- [x] Standarized setup for all roles
- [x]  Replace List with HashSet where is possible
- [x]  Make List, HashSet, Dictionary as readonly and in Init() use Clear() instead of = []; where is possible
- [x] RpcMurderPlayerV3 => RpcMurderPlayer
- [x] Add RpcCheckAndMurder & CheckForInvalidMurdering in some places of the code