### PR TITLE
RpcSetRole After ResetCams

### DIFF
--- a/Patches/ExilePatch.cs
+++ b/Patches/ExilePatch.cs
@@ -1,4 +1,5 @@
 ﻿using AmongUs.Data;
+using AmongUs.GameOptions;
 using HarmonyLib;
 using System.Linq;
 using TOHE.Roles.Crewmate;
@@ -248,6 +249,7 @@ class ExileControllerWrapUpPatch
             else if (player.GetCustomRole().IsGhostRole() || player.IsAnySubRole(x => x.IsGhostRole()))
             {
                 player.ResetPlayerCam(1f);
+                player.RpcSetRole(RoleTypes.GuardianAngel);
             }
 
             // Check for remove pet

--- a/Patches/PlayerControlPatch.cs
+++ b/Patches/PlayerControlPatch.cs
@@ -4470,6 +4470,7 @@ class PlayerControlSetRolePatch
                 if (target.IsAnySubRole(x => x.IsGhostRole()) || target.GetCustomRole().IsGhostRole())
                 {
                     roleType = RoleTypes.GuardianAngel;
+                    return true;
                 }
                 else if (ghostRoles.All(kvp => kvp.Value == RoleTypes.CrewmateGhost))
                 {


### PR DESCRIPTION
if this dosen't work at canary 7.
Then we will just disable it untill 2.0.0 where it already has changed.