### PR TITLE
Fix Player Stuck After Desync "BootFromVent"

### DIFF
--- a/Patches/PlayerControlPatch.cs
+++ b/Patches/PlayerControlPatch.cs
@@ -1326,27 +1326,15 @@ class CoEnterVentPatch
         }
 
         var playerRoleClass = __instance.myPlayer.GetRoleClass();
-        
-        // Fix Vent Stuck
+
+        // Prevent vanilla players from enter vents if their current role does not allow it
         if ((__instance.myPlayer.Data.Role.Role != RoleTypes.Engineer && !__instance.myPlayer.CanUseImpostorVentButton())
             || (playerRoleClass != null && playerRoleClass.CheckBootFromVent(__instance, id))
         )
         {
-            MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(__instance.NetId, (byte)RpcCalls.BootFromVent, SendOption.Reliable, -1);
-            writer.WritePacked(127);
-            AmongUsClient.Instance.FinishRpcImmediately(writer);
-            
-            _ = new LateTask(() =>
-            {
-                int clientId = __instance.myPlayer.GetClientId();
-                MessageWriter writer2 = AmongUsClient.Instance.StartRpcImmediately(__instance.NetId, (byte)RpcCalls.BootFromVent, SendOption.Reliable, clientId);
-                writer2.Write(id);
-                AmongUsClient.Instance.FinishRpcImmediately(writer2);
-            }, 0.5f, "Fix DesyncImpostor Stuck");
+            __instance.RpcBootFromVent(id);
             return false;
         }
-
-        
 
         playerRoleClass?.OnCoEnterVent(__instance, id);
 

--- a/Roles/Crewmate/Benefactor.cs
+++ b/Roles/Crewmate/Benefactor.cs
@@ -1,5 +1,4 @@
-﻿using Cpp2IL.Core.Extensions;
-using Hazel;
+﻿using Hazel;
 using System;
 using static TOHE.Translator;
 

--- a/Roles/Crewmate/Chameleon.cs
+++ b/Roles/Crewmate/Chameleon.cs
@@ -7,7 +7,6 @@ using TOHE.Roles.Core;
 using static TOHE.Utils;
 using static TOHE.Options;
 using static TOHE.Translator;
-using TOHE.Roles.AddOns.Common;
 
 namespace TOHE.Roles.Crewmate;
 


### PR DESCRIPTION
Fixed an issue where the player got stuck for some players after desync `BootFromVent` and errors appeared in the logs

![image](https://github.com/0xDrMoe/TownofHost-Enhanced/assets/104814436/9f0a0160-c7b0-46a6-8c53-c7c283d9930a)

![image](https://github.com/0xDrMoe/TownofHost-Enhanced/assets/104814436/87f70677-9828-4fb9-b877-9800a831d89e)
