### PR TITLE
 RoleBase - Dollmaster Overhaul!

### DIFF
--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -498,7 +498,7 @@ static class ExtendedPlayerControl
     public static bool HasKillButton(PlayerControl pc = null)
     {
         if (pc == null) return false;
-        if (!pc.IsAlive() || pc.Data.Role.Role == RoleTypes.GuardianAngel || Pelican.IsEaten(pc.PlayerId) || DollMaster.IsDoll(pc.PlayerId)) return false;
+        if (!pc.IsAlive() || pc.Data.Role.Role == RoleTypes.GuardianAngel || Pelican.IsEaten(pc.PlayerId)) return false;
         
         var role = pc.GetCustomRole();
         if (!role.IsImpostor())
@@ -529,7 +529,6 @@ static class ExtendedPlayerControl
     public static bool CanUseSabotage(this PlayerControl pc)
     {
         if (pc.Is(Custom_Team.Impostor) && !pc.IsAlive() && Options.DeadImpCantSabotage.GetBool()) return false;
-        if (DollMaster.IsDoll(pc.PlayerId)) return false;
 
         var playerRoleClass = pc.GetRoleClass();
         if (playerRoleClass != null && playerRoleClass.CanUseSabotage(pc)) return true;

--- a/Modules/NameColorManager.cs
+++ b/Modules/NameColorManager.cs
@@ -30,6 +30,8 @@ public static class NameColorManager
     }
     private static bool KnowTargetRoleColor(PlayerControl seer, PlayerControl target, bool isMeeting, out string color)
     {
+        target = DollMaster.SwapPlayerInfo(target); // If a player is possessed by the Dollmaster swap each other's controllers.
+
         color = seer.GetRoleClass()?.PlayerKnowTargetColor(seer, target); // returns "" unless overriden
         
         // Impostor & Madmate

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -396,6 +396,18 @@ public static class Utils
 
         var targetMainRole = Main.PlayerStates[targetId].MainRole;
         var targetSubRoles = Main.PlayerStates[targetId].SubRoles;
+        
+        // If a player is possessed by the Dollmaster swap each other's role and add-ons for display for every other client other than Dollmaster and target.
+        if (DollMaster.IsControllingPlayer)
+        {
+            if (!(DollMaster.DollMasterTarget == null || DollMaster.controllingTarget == null))
+            {
+                if (seerId != DollMaster.DollMasterTarget.PlayerId && targetId == DollMaster.DollMasterTarget.PlayerId)
+                    targetSubRoles = Main.PlayerStates[DollMaster.controllingTarget.PlayerId].SubRoles;
+                else if (seerId != DollMaster.controllingTarget.PlayerId && targetId == DollMaster.controllingTarget.PlayerId)
+                    targetSubRoles = Main.PlayerStates[DollMaster.DollMasterTarget.PlayerId].SubRoles;
+            }
+        }
 
         RoleText = GetRoleName(targetMainRole);
         RoleColor = GetRoleColor(targetMainRole);

--- a/Patches/PlayerControlPatch.cs
+++ b/Patches/PlayerControlPatch.cs
@@ -1173,6 +1173,9 @@ class FixedUpdateInNormalGamePatch
                 var seerRoleClass = seer.GetRoleClass();
                 var target = __instance;
 
+                if (seer != target)
+                    target = DollMaster.SwapPlayerInfo(target); // If a player is possessed by the Dollmaster swap each other's controllers.
+
                 string RealName = target.GetRealName();
 
                 Mark.Clear();

--- a/Resources/Lang/en_US.json
+++ b/Resources/Lang/en_US.json
@@ -3022,6 +3022,7 @@
   "DollMaster_CannotPossessImpTeammate": "Unable to possess teammate",
   "DollMaster_MainBody": "Main Body",
   "DollMaster_Doll": "Doll",
+  "DollMaster_UnableToUseAbility": "Unable to use ability on player",
   "EatenByDevourer": "Your skin was eaten by the Devourer",
   "DevourerEatenSkin": "Target skin eaten",
   "DevouredName": "Devoured",

--- a/Resources/Lang/en_US.json
+++ b/Resources/Lang/en_US.json
@@ -968,7 +968,7 @@
   "WardenInfoLong": "(Crewmates [Ghost]):\nAs the Warden, alert someone of nearby danger, additionally giving them a temporary speed boost.",
   "GhastlyInfoLong": "(Crewmates [Ghost]):\nAs the Ghastly, possess an unsuspecting person, thereafter choose a target for them, now they'll only be able to use their kill (or kill ability) on target until you possess someone else or possess time runs out.",
   "MinionInfoLong": "(Impostor [Ghost]):\nAs the Minion, you can temporarily blind non-impostors.",
-  "DollMasterInfoLong": "(Impostor):\nAs the Dollmaster, you can temporarily take control of any player by using the <color=#ff0000>Shapeshift</color> button and to make them do your Deeds, be careful though while possessing, the person you possess and your main body is fragile to killing roles!",
+  "DollMasterInfoLong": "(Impostor):\nAs the Dollmaster, you can temporarily take control of any player by using the <color=#ff0000>Shapeshift</color> button and to make them do your Deeds!",
   "ShowTextOverlay": "Text Overlay",
   "Overlay.GuesserMode": "<size=50%>Guesser Mode</size>",
   "Overlay.NoGameEnd": "<size=50%>No Game End</size>",

--- a/Roles/Core/CustomRoleManager.cs
+++ b/Roles/Core/CustomRoleManager.cs
@@ -142,6 +142,14 @@ public static class CustomRoleManager
         var killerRoleClass = killer.GetRoleClass();
         var killerSubRoles = killer.GetCustomSubRoles();
 
+        // If Target is possessed by Dollmaster swap controllers.
+        if (DollMaster.HasEnabled && DollMaster.IsControllingPlayer)
+        {
+            if (!(DollMaster.DollMasterTarget == null || DollMaster.controllingTarget == null))
+                if (target == DollMaster.DollMasterTarget || target == DollMaster.controllingTarget)
+                    target = target == DollMaster.controllingTarget? DollMaster.DollMasterTarget : DollMaster.controllingTarget;
+        }
+
         Logger.Info("Start", "PlagueBearer.CheckAndInfect");
 
         if (PlagueBearer.HasEnabled)
@@ -214,6 +222,26 @@ public static class CustomRoleManager
             return false;
         }
 
+        // Swap controllers if Sheriff shots Dollmasters main body.
+        if (DollMaster.HasEnabled && DollMaster.IsControllingPlayer)
+        {
+            if (killer.Is(CustomRoles.Sheriff) && target == DollMaster.DollMasterTarget)
+            {
+                if (!(DollMaster.DollMasterTarget == null || DollMaster.controllingTarget == null))
+                    if (target == DollMaster.DollMasterTarget || target == DollMaster.controllingTarget)
+                        target = target == DollMaster.controllingTarget ? DollMaster.DollMasterTarget : DollMaster.controllingTarget;
+            }
+        }
+
+        // Check if killer is a true killing role and Target is possessed by Dollmaster
+        if (DollMaster.HasEnabled && DollMaster.IsControllingPlayer)
+            if (!(DollMaster.DollMasterTarget == null || DollMaster.controllingTarget == null))
+                if (target == DollMaster.DollMasterTarget || target == DollMaster.controllingTarget)
+                {
+                    DollMaster.CheckMurderAsPossessed(killer, target);
+                    return false;
+                }
+                
         return true;
     }
     /// <summary>

--- a/Roles/Impostor/DollMaster.cs
+++ b/Roles/Impostor/DollMaster.cs
@@ -357,6 +357,7 @@ internal class DollMaster : RoleBase
 
     // A fix when the DollMaster or Possessed Player DC's from the game.
     // Untested!
+    /*
     public override void OnPlayerLeft(InnerNet.ClientData clientData)
     {
         if (DollMasterTarget == null || controllingTarget == null) return;
@@ -392,6 +393,7 @@ internal class DollMaster : RoleBase
             }, 0.35f);
         }
     }
+    */
 
     // Possess Player
     private static void Possess(PlayerControl pc, PlayerControl target, bool shouldAnimate = false)

--- a/Roles/Impostor/DollMaster.cs
+++ b/Roles/Impostor/DollMaster.cs
@@ -219,17 +219,48 @@ internal class DollMaster : RoleBase
         return true;
     }
 
+    // Prevent Dollmaster from killing main body
     public override bool OnCheckMurderAsKiller(PlayerControl killer, PlayerControl target) => (!(IsControllingPlayer && target == DollMasterTarget));
 
-    // Handle Sheriff killing Dollmaster while possessing.
+    // Handle specific killing roles when interacting with a Dollmaster or Player while possessing.
     public override bool CheckMurderOnOthersTarget(PlayerControl killer, PlayerControl target)
     {
-        if (IsControllingPlayer && killer.Is(CustomRoles.Sheriff) && killer != DollMasterTarget && target == DollMasterTarget)
+        if (IsControllingPlayer)
         {
-            CheckMurderAsPossessed(killer, target);
-            return true;
+            if (!CanKillerUseAbility(killer)) return true;
+
+            if (killer.Is(CustomRoles.Sheriff) && killer != DollMasterTarget && target == DollMasterTarget)
+            {
+                CheckMurderAsPossessed(killer, target);
+                return true;
+            }
         }
         return false;
+    }
+
+    // Check if Killer can use Ability on Target.
+    // This is a list of roles that are Buggy when interacting with a possessed player, therefore their ability will be canceled out.
+    private static bool CanKillerUseAbility(PlayerControl player)
+    {
+        var CanUseAbility = true;
+        var cRole = player.GetCustomRole();
+        var subRoles = player.GetCustomSubRoles(); // May use later on!
+
+        switch (cRole) // Check role.
+        {
+            case CustomRoles.Pelican:
+                CanUseAbility = false;
+                break;
+            case CustomRoles.Penguin:
+                CanUseAbility = false;
+                break;
+            default:
+                break;
+        }
+
+        if (!CanUseAbility) player.Notify(Utils.ColorString(player.GetRoleColor(), GetString("DollMaster_UnableToUseAbility")));
+
+        return CanUseAbility;
     }
 
     // Uno reverse kill.

--- a/Roles/Impostor/DollMaster.cs
+++ b/Roles/Impostor/DollMaster.cs
@@ -36,7 +36,7 @@ internal class DollMaster : RoleBase
 
     public override void SetupCustomOption()
     {
-        SetupRoleOptions(Id, TabGroup.OtherRoles, CustomRoles.DollMaster);
+        SetupSingleRoleOptions(Id, TabGroup.OtherRoles, CustomRoles.DollMaster);
         DefaultKillCooldown = FloatOptionItem.Create(Id + 10, "KillCooldown", new(0f, 180f, 2.5f), 25f, TabGroup.OtherRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.DollMaster])
             .SetValueFormat(OptionFormat.Seconds);
         ShapeshiftCooldown = FloatOptionItem.Create(Id + 11, "DollMasterPossessionCooldown", new(0f, 180f, 2.5f), 25f, TabGroup.OtherRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.DollMaster])


### PR DESCRIPTION
# Overhaul for Dollmaster from Dev 11

```diff
- Removed: Dollmaster and Possessed player are no longer fragile.
! Changed: Dollmaster LongInfo has been updated to compensate the removal above.
+ New: Dollmaster and possessed player roles display will swap when possessed.
+ New: Dollmaster and possessed player KnowTargetRoleColor will swap when possessed.
+ New: Dollmaster and possessed player GetMark will swap when possessed.
+ New: Interacting roles will now swap player controller info on possessed player or Dollmaster, for example Sheriff will now misfire on a possessed crewmate, or Monarch will Knight the Dollmaster if they interact with the main body, vice versa.
+ New: If Dollmaster starts a meeting by any means, it is redirected to possessed player.
= Fix: Added a new list of specific roles in DollMaster.cs that cannot interact with a possessed player due to bugs or issues, this list will probably be added onto in the future.
= Fix: Dollmaster unpossessing will now start waiting if possessed player cannot be teleported, beforehand it would only check if Dollmaster could be teleported to start waiting.
```