### PR TITLE
Addon base + more fixes for Dollmaster!

### DIFF
--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -634,6 +634,13 @@ static class ExtendedPlayerControl
     /// </summary>
     public static void RpcMurderPlayer(this PlayerControl killer, PlayerControl target)
     {
+        // If Target is Dollmaster or Possessed Player run Dollmasters kill check instead.
+        if (DollMaster.SwapPlayerInfo(target) != target)
+        {
+            DollMaster.CheckMurderAsPossessed(killer, target);
+            return;
+        }
+        
         killer.RpcMurderPlayer(target, true);
     }
 

--- a/Roles/Core/CustomRoleManager.cs
+++ b/Roles/Core/CustomRoleManager.cs
@@ -146,8 +146,11 @@ public static class CustomRoleManager
         var killerRoleClass = killer.GetRoleClass();
         var killerSubRoles = killer.GetCustomSubRoles();
 
-        // If Target is possessed by Dollmaster swap controllers.
-        target = DollMaster.SwapPlayerInfo(target);
+        if (DollMaster.HasEnabled)
+        {
+            // If Target is possessed by Dollmaster swap controllers.
+            target = DollMaster.SwapPlayerInfo(target);   
+        }
 
         Logger.Info("Start", "PlagueBearer.CheckAndInfect");
 
@@ -222,7 +225,7 @@ public static class CustomRoleManager
         }
 
         // Swap controllers if Sheriff shots Dollmasters main body.
-        if (killer.Is(CustomRoles.Sheriff) && target == DollMaster.DollMasterTarget)
+        if (DollMaster.HasEnabled && killer.Is(CustomRoles.Sheriff) && target == DollMaster.DollMasterTarget)
         {
             target = DollMaster.SwapPlayerInfo(target);
         }

--- a/Roles/Core/CustomRoleManager.cs
+++ b/Roles/Core/CustomRoleManager.cs
@@ -147,12 +147,7 @@ public static class CustomRoleManager
         var killerSubRoles = killer.GetCustomSubRoles();
 
         // If Target is possessed by Dollmaster swap controllers.
-        if (DollMaster.HasEnabled && DollMaster.IsControllingPlayer)
-        {
-            if (!(DollMaster.DollMasterTarget == null || DollMaster.controllingTarget == null))
-                if (target == DollMaster.DollMasterTarget || target == DollMaster.controllingTarget)
-                    target = target == DollMaster.controllingTarget? DollMaster.DollMasterTarget : DollMaster.controllingTarget;
-        }
+        target = DollMaster.SwapPlayerInfo(target);
 
         Logger.Info("Start", "PlagueBearer.CheckAndInfect");
 
@@ -227,14 +222,9 @@ public static class CustomRoleManager
         }
 
         // Swap controllers if Sheriff shots Dollmasters main body.
-        if (DollMaster.HasEnabled && DollMaster.IsControllingPlayer)
+        if (killer.Is(CustomRoles.Sheriff) && target == DollMaster.DollMasterTarget)
         {
-            if (killer.Is(CustomRoles.Sheriff) && target == DollMaster.DollMasterTarget)
-            {
-                if (!(DollMaster.DollMasterTarget == null || DollMaster.controllingTarget == null))
-                    if (target == DollMaster.DollMasterTarget || target == DollMaster.controllingTarget)
-                        target = target == DollMaster.controllingTarget ? DollMaster.DollMasterTarget : DollMaster.controllingTarget;
-            }
+            target = DollMaster.SwapPlayerInfo(target);
         }
 
         // Check if killer is a true killing role and Target is possessed by Dollmaster
@@ -257,6 +247,9 @@ public static class CustomRoleManager
         // When using this code, keep in mind that killer and target can be equal (Suicide)
         // And the player can also die during the Meeting
         // ################################
+
+        PlayerControl trueDMKiller = killer; // Save real killer.
+        killer = DollMaster.SwapPlayerInfo(killer); // If "killer" is possessed by the Dollmaster swap each other's controllers.
 
         var killerRoleClass = killer.GetRoleClass();
         var targetRoleClass = target.GetRoleClass();
@@ -281,7 +274,7 @@ public static class CustomRoleManager
                         break;
 
                     case CustomRoles.Bait when !inMeeting:
-                        Bait.BaitAfterDeathTasks(killer, target);
+                        Bait.BaitAfterDeathTasks(trueDMKiller, target); // Use trueDMKiller to any roles that needs the Dollmaster to be the killer!
                         break;
 
                     case CustomRoles.Trapper when !inMeeting && !isSuicide && !killer.Is(CustomRoles.KillingMachine):


### PR DESCRIPTION
# Even More Dollmaster Fixes!
Yeah there's a good reason why this role is experimental lmao.
## Dollmaster:
```diff
+ Simplified some Dollmaster code for OnCheckMurder.
! Fixed issue with burst activating on a possessed player.
! Additionally fixed all issues with trapped based add-ons activating on possessed player.
! Fixed issue when other roles called player.RpcMurderPlayer(player) on possessed player.
=== Now if RpcMurderPlayer is called on a Possessed Player or Dollmaster possessing, it will run Dollmasters CheckMurderAsPossessed instead.
```