### PR TITLE
Make Disconnected as player state instead of Death Reason

### DIFF
--- a/Modules/GameOptionsSender/PlayerGameOptionsSender.cs
+++ b/Modules/GameOptionsSender/PlayerGameOptionsSender.cs
@@ -109,7 +109,7 @@ public class PlayerGameOptionsSender(PlayerControl player) : GameOptionsSender
         /*
          * Builds Modified GameOptions
          */
-        player.BuildCustomGameOptions(ref opt, role);
+        player.BuildCustomGameOptions(ref opt);
 
         AURoleOptions.EngineerCooldown = Mathf.Max(0.01f, AURoleOptions.EngineerCooldown);
 

--- a/Modules/GameState.cs
+++ b/Modules/GameState.cs
@@ -18,6 +18,7 @@ public class PlayerState(byte playerId)
     public List<CustomRoles> SubRoles = [];
     public CountTypes countTypes = CountTypes.OutOfGame;
     public bool IsDead { get; set; } = false;
+    public bool Disconnected { get; set; } = false;
 #pragma warning disable IDE1006 // Naming Styles
     public DeathReason deathReason { get; set; } = DeathReason.etc;
 #pragma warning restore IDE1006
@@ -271,7 +272,6 @@ public class PlayerState(byte playerId)
         Sniped,
         Revenge,
         Execution,
-        Disconnected,
         Fall,
 
         // TOHE

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -592,7 +592,7 @@ internal class RPCHandlerPatch
                 Keeper.ReceiveRPC(reader);
                 break;
             case CustomRPC.SetSwapperVotes:
-                Swapper.ReceiveSwapRPC(reader, __instance);
+                Swapper.ReceiveSwapRPC(reader);
                 break;
         }
     }

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -2099,7 +2099,7 @@ public static class Utils
         }
         else { TaskCount = GetProgressText(id); }
 
-        var disconnectedText = playerState.deathReason != PlayerState.DeathReason.etc && playerState.Disconnected ? $" ({GetString("Disconnected")})" : string.Empty;
+        var disconnectedText = playerState.deathReason != PlayerState.DeathReason.etc && playerState.Disconnected ? $"({GetString("Disconnected")})" : string.Empty;
         string summary = $"{ColorString(Main.PlayerColors[id], name)} - {GetDisplayRoleAndSubName(id, id, true)}{GetSubRolesText(id, summary: true)}{TaskCount} {GetKillCountText(id)} 『{GetVitalText(id, true)}』{disconnectedText}";
         switch (Options.CurrentGameMode)
         {

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -2099,8 +2099,8 @@ public static class Utils
         }
         else { TaskCount = GetProgressText(id); }
 
-        var disconnectedText = playerState.deathReason != PlayerState.DeathReason.etc && playerState.Disconnected ? $"({GetString("Disconnected")})" : string.Empty;
-        string summary = $"{ColorString(Main.PlayerColors[id], name)} - {GetDisplayRoleAndSubName(id, id, true)}{GetSubRolesText(id, summary: true)}{TaskCount} {GetKillCountText(id)} 『{GetVitalText(id, true)}』 {disconnectedText}";
+        var disconnectedText = playerState.deathReason != PlayerState.DeathReason.etc && playerState.Disconnected ? $" ({GetString("Disconnected")})" : string.Empty;
+        string summary = $"{ColorString(Main.PlayerColors[id], name)} - {GetDisplayRoleAndSubName(id, id, true)}{GetSubRolesText(id, summary: true)}{TaskCount} {GetKillCountText(id)} 『{GetVitalText(id, true)}』{disconnectedText}";
         switch (Options.CurrentGameMode)
         {
             case CustomGameMode.FFA:

--- a/Patches/PlayerJoinAndLeftPatch.cs
+++ b/Patches/PlayerJoinAndLeftPatch.cs
@@ -307,11 +307,8 @@ class OnPlayerLeftPatch
 
                 if (Spiritualist.HasEnabled) Spiritualist.RemoveTarget(data.Character.PlayerId);
 
-                if (Main.PlayerStates[data.Character.PlayerId].deathReason == PlayerState.DeathReason.etc) // If no cause of death was established
-                {
-                    Main.PlayerStates[data.Character.PlayerId].deathReason = PlayerState.DeathReason.Disconnected;
-                    Main.PlayerStates[data.Character.PlayerId].SetDead();
-                }
+                Main.PlayerStates[data.Character.PlayerId].Disconnected = true;
+                Main.PlayerStates[data.Character.PlayerId].SetDead();
 
                 // if the player left while he had a Notice message, clear it
                 if (NameNotifyManager.Notifying(data.Character))

--- a/Resources/Lang/en_US.json
+++ b/Resources/Lang/en_US.json
@@ -1873,7 +1873,6 @@
   "DeathReason.Torched": "Burned",
   "DeathReason.Sniped": "Sniped",
   "DeathReason.Execution": "Executed",
-  "DeathReason.Disconnected": "Disconnected",
   "DeathReason.Fall": "Fall",
   "DeathReason.Revenge": "Revenge",
   "DeathReason.Eaten": "Eaten",
@@ -1902,6 +1901,7 @@
   "DeathReason.BloodLet": "Bleed",
   "OnlyEnabledDeathReasons": "Only Enabled Death Reasons",
   "Alive": "Alive",
+  "Disconnected": "Disconnected",
   "Win": " Wins!",
 
   "Last-": "Last ",

--- a/Roles/AddOns/Impostor/Tricky.cs
+++ b/Roles/AddOns/Impostor/Tricky.cs
@@ -26,7 +26,7 @@ public static class Tricky
     }
     private static bool IsReasonEnabled( this PlayerState.DeathReason reason)
     {
-        if (reason is PlayerState.DeathReason.Disconnected or PlayerState.DeathReason.etc) return false;
+        if (reason is PlayerState.DeathReason.etc) return false;
         if (!EnabledDeathReasons.GetBool()) return true;
         return reason.DeathReasonIsEnable();
     }

--- a/Roles/Core/CustomRoleManager.cs
+++ b/Roles/Core/CustomRoleManager.cs
@@ -75,7 +75,7 @@ public static class CustomRoleManager
     /// <summary>
     /// Builds Modified GameOptions
     /// </summary>
-    public static void BuildCustomGameOptions(this PlayerControl player, ref IGameOptions opt, CustomRoles role)
+    public static void BuildCustomGameOptions(this PlayerControl player, ref IGameOptions opt)
     {
         if (player.IsAnySubRole(x => x is CustomRoles.EvilSpirit))
         {

--- a/Roles/Crewmate/Swapper.cs
+++ b/Roles/Crewmate/Swapper.cs
@@ -350,7 +350,7 @@ internal class Swapper : RoleBase
         writer.Write(playerId);
         AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
-    public static void ReceiveSwapRPC(MessageReader reader, PlayerControl pc)
+    public static void ReceiveSwapRPC(MessageReader reader)
     {
         byte PlayerId = reader.ReadByte();
         if (Main.PlayerStates[PlayerId].RoleClass is Swapper sw) sw.SwapMsg($"/sw {PlayerId}");

--- a/Roles/Neutral/Quizmaster.cs
+++ b/Roles/Neutral/Quizmaster.cs
@@ -521,19 +521,19 @@ class DeathReasonQuestion : QuizQuestionBase
         {
             PossibleAnswers.Add("None");
             PossibleAnswers.Add(PlayerState.DeathReason.etc.ToString());
-            PossibleAnswers.Add(PlayerState.DeathReason.Vote.ToString());
+            PossibleAnswers.Add(GetString("DeathReason.Vote"));
         }
         else if (QuizmasterQuestionType == QuizmasterQuestionType.PlrDeathMethodQuestion)
         {
-            PossibleAnswers.Add(PlayerState.DeathReason.Disconnected.ToString());
-            PossibleAnswers.Add(PlayerState.DeathReason.Vote.ToString());
-            PossibleAnswers.Add(PlayerState.DeathReason.Kill.ToString());
+            PossibleAnswers.Add(GetString("Disconnected"));
+            PossibleAnswers.Add(GetString("DeathReason.Vote"));
+            PossibleAnswers.Add(GetString("DeathReason.Kill"));
         }
         else if (QuizmasterQuestionType == QuizmasterQuestionType.PlrDeathKillerFactionQuestion)
         {
             PossibleAnswers.Add("");
-            PossibleAnswers.Add(PlayerState.DeathReason.Vote.ToString());
-            PossibleAnswers.Add(PlayerState.DeathReason.Kill.ToString());
+            PossibleAnswers.Add(GetString("DeathReason.Vote"));
+            PossibleAnswers.Add(GetString("DeathReason.Kill"));
         }
 
         chosenPlayer = Main.AllPlayerControls[rnd.Next(Main.AllPlayerControls.Length)];
@@ -557,7 +557,7 @@ class DeathReasonQuestion : QuizQuestionBase
         Answer = QuizmasterQuestionType switch
         {
             QuizmasterQuestionType.PlrDeathReasonQuestion => chosenPlayer.Data.IsDead ? Main.PlayerStates[chosenPlayer.PlayerId].deathReason.ToString() : "None",
-            QuizmasterQuestionType.PlrDeathMethodQuestion => chosenPlayer.Data.Disconnected ? PlayerState.DeathReason.Disconnected.ToString() : (Main.PlayerStates[chosenPlayer.PlayerId].deathReason == PlayerState.DeathReason.Vote ? PlayerState.DeathReason.Vote.ToString() : PlayerState.DeathReason.Kill.ToString()),
+            QuizmasterQuestionType.PlrDeathMethodQuestion => chosenPlayer.Data.Disconnected ? GetString("Disconnected") : (Main.PlayerStates[chosenPlayer.PlayerId].deathReason == PlayerState.DeathReason.Vote ? GetString("DeathReason.Vote") : GetString("DeathReason.Kill")),
             QuizmasterQuestionType.PlrDeathKillerFactionQuestion => CustomRolesHelper.GetRoleTypes(chosenPlayer.GetRealKiller().GetCustomRole()).ToString(),
             _ => "None"
         };

--- a/Roles/Neutral/Solsticer.cs
+++ b/Roles/Neutral/Solsticer.cs
@@ -250,7 +250,7 @@ internal class Solsticer : RoleBase
     }
     public static void SetShortTasksToAdd()
     {
-        var TotalPlayer = Main.PlayerStates.Count(x => x.Value.deathReason != PlayerState.DeathReason.Disconnected);
+        var TotalPlayer = Main.PlayerStates.Count(x => x.Value.Disconnected == false);
         var AlivePlayer = Main.AllAlivePlayerControls.Length;
 
         AddShortTasks = (int)((TotalPlayer - AlivePlayer) * AddTasksPreDeadPlayer.GetFloat());

--- a/Roles/Neutral/SoulCollector.cs
+++ b/Roles/Neutral/SoulCollector.cs
@@ -113,7 +113,8 @@ internal class SoulCollector : RoleBase
         {
             if (targetId == byte.MaxValue) continue;
 
-            if (targetId == deadPlayer.PlayerId && Main.PlayerStates[targetId].deathReason != PlayerState.DeathReason.Disconnected)
+            Main.PlayerStates.TryGetValue(targetId, out var playerState);
+            if (targetId == deadPlayer.PlayerId && playerState.IsDead && playerState.deathReason != PlayerState.DeathReason.etc) // "ect" if player not left
             {
                 SoulCollectorTarget[playerId] = byte.MaxValue;
                 SoulCollectorPoints[playerId]++;

--- a/Roles/Neutral/SoulCollector.cs
+++ b/Roles/Neutral/SoulCollector.cs
@@ -114,7 +114,7 @@ internal class SoulCollector : RoleBase
             if (targetId == byte.MaxValue) continue;
 
             Main.PlayerStates.TryGetValue(targetId, out var playerState);
-            if (targetId == deadPlayer.PlayerId && playerState.IsDead && playerState.deathReason != PlayerState.DeathReason.etc) // "ect" if player not left
+            if (targetId == deadPlayer.PlayerId && playerState.IsDead && playerState.deathReason != PlayerState.DeathReason.etc) // if player death reason is "ect", then player was left the game
             {
                 SoulCollectorTarget[playerId] = byte.MaxValue;
                 SoulCollectorPoints[playerId]++;


### PR DESCRIPTION
Now at the end of the game the real cause of death will be displayed and the player's status next to it

If the player never died and just left then Disconnected will be the main cause of death

![image](https://github.com/0xDrMoe/TownofHost-Enhanced/assets/104814436/c6ab1d2f-539e-450b-8657-62a1b2a96f5c)
![image](https://github.com/0xDrMoe/TownofHost-Enhanced/assets/104814436/56dad69f-417e-48ec-8434-89d7398cb732)
