### PR TITLE
Display Team Name For Vanilla

### DIFF
--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -1649,37 +1649,29 @@ public static class Utils
         //target: seer updates nickname/role/mark of other targets
         foreach (var seer in seerList)
         {
-            // During intro scene to set team name for non-modded clients and skip the rest.
-            if (SetUpRoleTextPatch.IsInIntro)
-            {
-                var player = seer;
-                if (player.IsModClient()) continue; // Only non-modded players
-
-                string IconText = "<color=#ffffff>|</color>";
-                string SelfTeamName = $"<size=450%>{IconText} <font=\"VCR SDF\" material=\"VCR Black Outline\">{Utils.ColorString(Utils.GetTeamColor(player), $"{player.GetCustomRole().GetCustomRoleTeam()}")}</font> {IconText}</size><size=900%>\n \n</size>";
-                string SelfRoleName = $"{player.GetDisplayRoleAndSubName(player, false)}";
-                string SeerRealName = player.GetRealName();
-                string SelfName = $"{Utils.ColorString(player.GetRoleColor(), SeerRealName)}";
-                string RoleNameUp = "</size><size=1350%>\n \n</size>";
-
-                SelfName = $"{SelfTeamName}\r\n{SelfRoleName}\r\n{SelfName}{RoleNameUp}";
-
-                // Privately sent name.
-                var sender = CustomRpcSender.Create(name: $"SetNamePrivate");
-                sender.AutoStartRpc(player.NetId, (byte)RpcCalls.SetName, player.GetClientId())
-                    .Write(SelfName)
-                    .Write(true)
-                .EndRpc();
-                sender.SendMessage();
-                continue;
-            }
-
             // Do nothing when the seer is not present in the game
             if (seer == null || seer.Data.Disconnected) continue;
             
             // Only non-modded players
             if (seer.IsModClient()) continue;
 
+            // During intro scene, set team name for non-modded clients and skip the rest.
+            if (SetUpRoleTextPatch.IsInIntro)
+            {
+                string IconText = "<color=#ffffff>|</color>";
+                string SelfTeamName = $"<size=450%>{IconText} <font=\"VCR SDF\" material=\"VCR Black Outline\">{Utils.ColorString(Utils.GetTeamColor(seer), $"{seer.GetCustomRole().GetCustomRoleTeam()}")}</font> {IconText}</size><size=900%>\n \n</size>";
+                string SelfRoleName = $"{seer.GetDisplayRoleAndSubName(seer, false)}";
+                string SeerRealName = seer.GetRealName();
+                string SelfName = $"{Utils.ColorString(seer.GetRoleColor(), SeerRealName)}";
+                string RoleNameUp = "</size><size=1350%>\n \n</size>";
+
+                SelfName = $"{SelfTeamName}\r\n{SelfRoleName}\r\n{SelfName}{RoleNameUp}";
+
+                // Privately sent name.
+                seer.RpcSetNamePrivate(SelfName, true, seer);
+                continue;
+            }
+            
             // Size of player roles
             string fontSize = "1.5";
             if (isForMeeting && (seer.GetClient().PlatformData.Platform == Platforms.Playstation || seer.GetClient().PlatformData.Platform == Platforms.Switch)) fontSize = "70%";

--- a/Patches/IntroPatch.cs
+++ b/Patches/IntroPatch.cs
@@ -14,9 +14,18 @@ namespace TOHE;
 [HarmonyPatch(typeof(IntroCutscene), nameof(IntroCutscene.ShowRole))]
 class SetUpRoleTextPatch
 {
+    public static bool IsInIntro = false;
+
     public static void Postfix(IntroCutscene __instance)
     {
         if (!GameStates.IsModHost) return;
+
+        // After showing team for non-modded clients update player names.
+        _ = new LateTask(() =>
+        {
+            IsInIntro = false;
+            Utils.NotifyRoles();
+        }, 2f);
 
         _ = new LateTask(() =>
         {

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -17,6 +17,8 @@ internal class ChangeRoleSettings
 {
     public static void Postfix(AmongUsClient __instance)
     {
+        SetUpRoleTextPatch.IsInIntro = true;
+
         Main.OverrideWelcomeMsg = "";
 
         Logger.Msg("Is Started", "AssignRoles");


### PR DESCRIPTION
# Overview
Plain and simple, Made it where vanilla clients can see their team on intro scene!
![RoleTeam](https://github.com/0xDrMoe/TownofHost-Enhanced/assets/83262852/a98ae1e8-ae61-4a6c-9d4b-86ff0d008a04)
## Futures:
```diff
+ | Display Team Name for Vanilla clients on intro
+ | Added Utility: Get Team Color
```