### PR TITLE
Doppelganger Code Overhaul

### DIFF
--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -998,6 +998,11 @@ static class ExtendedPlayerControl
         {
             return false;
         }
+        
+        // If doppelganger appears as player return true
+        // Note: Needs to be tested for any buggy outcomes.
+        if (Doppelganger.CheckDoppelVictim(target.PlayerId) && target.PlayerId == Doppelganger.CurrentIdToSwap)
+            return true;
 
         //if the target status is alive
         return !Main.PlayerStates.TryGetValue(target.PlayerId, out var playerState) || !playerState.IsDead;

--- a/Modules/NameColorManager.cs
+++ b/Modules/NameColorManager.cs
@@ -32,6 +32,8 @@ public static class NameColorManager
     {
         target = DollMaster.SwapPlayerInfo(target); // If a player is possessed by the Dollmaster swap each other's controllers.
 
+        target = Doppelganger.SwapPlayerInfoFromRom(target); // If player is victim to Doppelganger swap each other's controllers
+
         color = seer.GetRoleClass()?.PlayerKnowTargetColor(seer, target); // returns "" unless overriden
         
         // Impostor & Madmate

--- a/Modules/NameColorManager.cs
+++ b/Modules/NameColorManager.cs
@@ -30,9 +30,11 @@ public static class NameColorManager
     }
     private static bool KnowTargetRoleColor(PlayerControl seer, PlayerControl target, bool isMeeting, out string color)
     {
+        if (seer != target)
         target = DollMaster.SwapPlayerInfo(target); // If a player is possessed by the Dollmaster swap each other's controllers.
 
-        target = Doppelganger.SwapPlayerInfoFromRom(target); // If player is victim to Doppelganger swap each other's controllers
+        if (seer != target && seer.IsAlive())
+            target = Doppelganger.SwapPlayerInfoFromRom(target); // If player is victim to Doppelganger swap each other's controllers
 
         color = seer.GetRoleClass()?.PlayerKnowTargetColor(seer, target); // returns "" unless overriden
         

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -1860,14 +1860,6 @@ public static class Utils
 
                         string TargetPlayerName = target.GetRealName(isForMeeting);
 
-                        if (seer.Data.IsDead)
-                        {
-                            if (target.Is(CustomRoles.Doppelganger))
-                                TargetPlayerName = $"{Doppelganger.DoppelPresentSkin[realTarget.PlayerId].PlayerName}\r\n<size=75%>{TargetPlayerName}</size>";
-                            else if (Doppelganger.CheckDoppelVictim(realTarget.PlayerId))
-                                TargetPlayerName = Doppelganger.DoppelPresentSkin[realTarget.PlayerId].PlayerName;
-                        }
-
                         var tempNameText = seer.GetRoleClass()?.NotifyPlayerName(seer, target, TargetPlayerName, isForMeeting);
                         if (tempNameText != string.Empty)
                             TargetPlayerName = tempNameText;

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -1801,10 +1801,18 @@ public static class Utils
                 || NoCache
                 || ForceLoop))
             {
-                foreach (var target in targetList)
+                foreach (var realTarget in targetList)
                 {
                     // if the target is the seer itself, do nothing
-                    if (target.PlayerId == seer.PlayerId) continue;
+                    if (realTarget.PlayerId == seer.PlayerId) continue;
+
+                    var target = realTarget;
+
+                    if (seer != target && seer != DollMaster.DollMasterTarget)
+                        target = DollMaster.SwapPlayerInfo(target); // If a player is possessed by the Dollmaster swap each other's controllers.
+
+                    if (seer != target && seer.IsAlive())
+                        target = Doppelganger.SwapPlayerInfoFromRom(target); // If player is victim to Doppelganger swap each other's controllers
 
                     //logger.Info("NotifyRoles-Loop2-" + target.GetNameWithRole() + ":START");
 
@@ -1851,6 +1859,11 @@ public static class Utils
                         // ====== Target player name ======
 
                         string TargetPlayerName = target.GetRealName(isForMeeting);
+
+                        if (seer.Data.IsDead && target.Is(CustomRoles.Doppelganger))
+                        {
+                            TargetPlayerName = $"{Doppelganger.DoppelPresentSkin[realTarget.PlayerId].PlayerName}\r\n<size=75%>{TargetPlayerName}</size>";
+                        }
 
                         var tempNameText = seer.GetRoleClass()?.NotifyPlayerName(seer, target, TargetPlayerName, isForMeeting);
                         if (tempNameText != string.Empty)

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -1860,9 +1860,12 @@ public static class Utils
 
                         string TargetPlayerName = target.GetRealName(isForMeeting);
 
-                        if (seer.Data.IsDead && target.Is(CustomRoles.Doppelganger))
+                        if (seer.Data.IsDead)
                         {
-                            TargetPlayerName = $"{Doppelganger.DoppelPresentSkin[realTarget.PlayerId].PlayerName}\r\n<size=75%>{TargetPlayerName}</size>";
+                            if (target.Is(CustomRoles.Doppelganger))
+                                TargetPlayerName = $"{Doppelganger.DoppelPresentSkin[realTarget.PlayerId].PlayerName}\r\n<size=75%>{TargetPlayerName}</size>";
+                            else if (Doppelganger.CheckDoppelVictim(realTarget.PlayerId))
+                                TargetPlayerName = Doppelganger.DoppelPresentSkin[realTarget.PlayerId].PlayerName;
                         }
 
                         var tempNameText = seer.GetRoleClass()?.NotifyPlayerName(seer, target, TargetPlayerName, isForMeeting);

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -1914,9 +1914,9 @@ public static class Utils
                         // if Victim to Doppelganger or is Doppelganger
                         if (seer.Data.IsDead && Doppelganger.HasEnabled && Doppelganger.DoppelVictim.Count > 1)
                         {
-                            if (target.Is(CustomRoles.Doppelganger))
+                            if (target.Is(CustomRoles.Doppelganger) && Doppelganger.TrueNames.ContainsKey(target.PlayerId))
                                 TargetPlayerName = $"{TargetPlayerName}\r\n<size=75%>{ColorString(Color.gray, $"({Doppelganger.TrueNames[target.PlayerId]})")}</size>";
-                            else if (Doppelganger.CheckDoppelVictim(target.PlayerId))
+                            else if (Doppelganger.CheckDoppelVictim(target.PlayerId) && Doppelganger.TrueNames.ContainsKey(target.PlayerId))
                                 TargetPlayerName = Doppelganger.TrueNames[target.PlayerId];
                         }
 

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -1823,7 +1823,7 @@ public static class Utils
                     // Hide player names in during Mushroom Mixup if seer is alive and desync impostor
                     if (!CamouflageIsForMeeting && MushroomMixupIsActive && target.IsAlive() && !seer.Is(Custom_Team.Impostor) && Main.ResetCamPlayerList.Contains(seer.PlayerId))
                     {
-                        target.RpcSetNamePrivate("<size=0%>", true, force: NoCache);
+                        realTarget.RpcSetNamePrivate("<size=0%>", true, force: NoCache);
                     }
                     else
                     {
@@ -1863,6 +1863,9 @@ public static class Utils
                         // ====== Target player name ======
 
                         string TargetPlayerName = target.GetRealName(isForMeeting);
+
+                        if (seer != target && seer.IsAlive())
+                            target = Doppelganger.SwapPlayerInfoFromRom(target); // If player is victim to Doppelganger swap each other's controllers
 
                         // if Victim to Doppelganger or is Doppelganger
                         if (seer.Data.IsDead)
@@ -1960,7 +1963,7 @@ public static class Utils
                         string TargetName = $"{TargetRoleText}{TargetPlayerName}{TargetDeathReason}{TargetMark}{TargetSuffix}";
                         //TargetName += TargetSuffix.ToString() == "" ? "" : ("\r\n" + TargetSuffix.ToString());
 
-                        target.RpcSetNamePrivate(TargetName, true, seer, force: NoCache);
+                        realTarget.RpcSetNamePrivate(TargetName, true, seer, force: NoCache);
                     }
                 }
             }

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -1730,6 +1730,10 @@ public static class Utils
 
                 string SeerRealName = seer.GetRealName(isForMeeting);
 
+                // Set self name to true name if Victim to Doppelganger
+                if (seer.Data.IsDead && Doppelganger.CheckDoppelVictim(seer.PlayerId))
+                    SeerRealName = Doppelganger.TrueNames[seer.PlayerId];
+
                 if (MeetingStates.FirstMeeting && Options.ChangeNameToRoleInfo.GetBool() && !isForMeeting && Options.CurrentGameMode != CustomGameMode.FFA)
                 {
                     var SeerRoleInfo = seer.GetRoleInfo();
@@ -1859,6 +1863,15 @@ public static class Utils
                         // ====== Target player name ======
 
                         string TargetPlayerName = target.GetRealName(isForMeeting);
+
+                        // if Victim to Doppelganger or is Doppelganger
+                        if (seer.Data.IsDead)
+                        {
+                            if (target.Is(CustomRoles.Doppelganger))
+                                TargetPlayerName = $"{TargetPlayerName}\r\n<size=75%>({ColorString(Color.gray, Doppelganger.TrueNames[target.PlayerId])})</size>";
+                            else if (Doppelganger.CheckDoppelVictim(target.PlayerId))
+                                TargetPlayerName = Doppelganger.TrueNames[target.PlayerId];
+                        }
 
                         var tempNameText = seer.GetRoleClass()?.NotifyPlayerName(seer, target, TargetPlayerName, isForMeeting);
                         if (tempNameText != string.Empty)

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -1731,7 +1731,7 @@ public static class Utils
                 string SeerRealName = seer.GetRealName(isForMeeting);
 
                 // Set self name to true name if Victim to Doppelganger
-                if (seer.Data.IsDead && Doppelganger.CheckDoppelVictim(seer.PlayerId))
+                if (seer.Data.IsDead && Doppelganger.TrueNames.ContainsKey(seer.PlayerId) && Doppelganger.CheckDoppelVictim(seer.PlayerId))
                     SeerRealName = Doppelganger.TrueNames[seer.PlayerId];
 
                 if (MeetingStates.FirstMeeting && Options.ChangeNameToRoleInfo.GetBool() && !isForMeeting && Options.CurrentGameMode != CustomGameMode.FFA)

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -1912,7 +1912,7 @@ public static class Utils
                             target = Doppelganger.SwapPlayerInfoFromRom(target); // If player is victim to Doppelganger swap each other's controllers
 
                         // if Victim to Doppelganger or is Doppelganger
-                        if (seer.Data.IsDead)
+                        if (seer.Data.IsDead && Doppelganger.HasEnabled && Doppelganger.DoppelVictim.Count > 1)
                         {
                             if (target.Is(CustomRoles.Doppelganger))
                                 TargetPlayerName = $"{TargetPlayerName}\r\n<size=75%>{ColorString(Color.gray, $"({Doppelganger.TrueNames[target.PlayerId]})")}</size>";

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -1868,7 +1868,7 @@ public static class Utils
                         if (seer.Data.IsDead)
                         {
                             if (target.Is(CustomRoles.Doppelganger))
-                                TargetPlayerName = $"{TargetPlayerName}\r\n<size=75%>({ColorString(Color.gray, Doppelganger.TrueNames[target.PlayerId])})</size>";
+                                TargetPlayerName = $"{TargetPlayerName}\r\n<size=75%>{ColorString(Color.gray, $"({Doppelganger.TrueNames[target.PlayerId]})")}</size>";
                             else if (Doppelganger.CheckDoppelVictim(target.PlayerId))
                                 TargetPlayerName = Doppelganger.TrueNames[target.PlayerId];
                         }

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -992,9 +992,9 @@ class MeetingHudStartPatch
             // if Victim to Doppelganger or is Doppelganger
             if (seer.Data.IsDead && Doppelganger.HasEnabled && Doppelganger.DoppelVictim.Count > 1)
             {
-                if (target.Is(CustomRoles.Doppelganger))
+                if (target.Is(CustomRoles.Doppelganger) && Doppelganger.TrueNames.ContainsKey(target.PlayerId))
                     pva.NameText.text = $"{Utils.ColorString(Color.gray, $"<size=75%>({Doppelganger.TrueNames[target.PlayerId]})</size>")}\r\n{pva.NameText.text.ApplyNameColorData(seer, target, true)}\n\n";
-                else if (Doppelganger.CheckDoppelVictim(target.PlayerId))
+                else if (Doppelganger.CheckDoppelVictim(target.PlayerId) && Doppelganger.TrueNames.ContainsKey(target.PlayerId))
                     pva.NameText.text = Doppelganger.TrueNames[target.PlayerId].ApplyNameColorData(seer, target, true);
             }
 

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -990,7 +990,7 @@ class MeetingHudStartPatch
             pva.NameText.text = pva.NameText.text.ApplyNameColorData(seer, target, true);
             
             // if Victim to Doppelganger or is Doppelganger
-            if (seer.Data.IsDead)
+            if (seer.Data.IsDead && Doppelganger.HasEnabled && Doppelganger.DoppelVictim.Count > 1)
             {
                 if (target.Is(CustomRoles.Doppelganger))
                     pva.NameText.text = $"{Utils.ColorString(Color.gray, $"<size=75%>({Doppelganger.TrueNames[target.PlayerId]})</size>")}\r\n{pva.NameText.text.ApplyNameColorData(seer, target, true)}\n\n";

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -993,7 +993,7 @@ class MeetingHudStartPatch
             if (seer.Data.IsDead)
             {
                 if (target.Is(CustomRoles.Doppelganger))
-                    pva.NameText.text += Utils.ColorString(Color.gray, $"\r\n<size=75%>({Doppelganger.TrueNames[target.PlayerId]})</size>\n\n");
+                    pva.NameText.text = $"{Utils.ColorString(Color.gray, $"<size=75%>({Doppelganger.TrueNames[target.PlayerId]})</size>")}\r\n{pva.NameText.text.ApplyNameColorData(seer, target, true)}\n\n";
                 else if (Doppelganger.CheckDoppelVictim(target.PlayerId))
                     pva.NameText.text = Doppelganger.TrueNames[target.PlayerId].ApplyNameColorData(seer, target, true);
             }

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -988,7 +988,15 @@ class MeetingHudStartPatch
             var sb = new StringBuilder();
 
             pva.NameText.text = pva.NameText.text.ApplyNameColorData(seer, target, true);
-
+            
+            // if Victim to Doppelganger or is Doppelganger
+            if (seer.Data.IsDead)
+            {
+                if (target.Is(CustomRoles.Doppelganger))
+                    pva.NameText.text += Utils.ColorString(Color.gray, $"\r\n<size=75%>({Doppelganger.TrueNames[target.PlayerId]})</size>\n\n");
+                else if (Doppelganger.CheckDoppelVictim(target.PlayerId))
+                    pva.NameText.text = Doppelganger.TrueNames[target.PlayerId].ApplyNameColorData(seer, target, true);
+            }
 
             // Guesser Mode //
             if (Options.GuesserMode.GetBool())

--- a/Patches/PlayerControlPatch.cs
+++ b/Patches/PlayerControlPatch.cs
@@ -1138,9 +1138,13 @@ class FixedUpdateInNormalGamePatch
                 var seer = PlayerControl.LocalPlayer;
                 var seerRoleClass = seer.GetRoleClass();
                 var target = __instance;
+                var realTarget = target;
 
                 if (seer != target && seer != DollMaster.DollMasterTarget)
                     target = DollMaster.SwapPlayerInfo(target); // If a player is possessed by the Dollmaster swap each other's controllers.
+
+                if (seer != target && seer.IsAlive())
+                    target = Doppelganger.SwapPlayerInfoFromRom(target); // If player is victim to Doppelganger swap each other's controllers
 
                 string RealName = target.GetRealName();
 

--- a/Patches/PlayerControlPatch.cs
+++ b/Patches/PlayerControlPatch.cs
@@ -1137,9 +1137,9 @@ class FixedUpdateInNormalGamePatch
                 // if Victim to Doppelganger or is Doppelganger
                 if (seer.Data.IsDead && Doppelganger.HasEnabled && Doppelganger.DoppelVictim.Count > 1)
                 {
-                    if (target.Is(CustomRoles.Doppelganger))
+                    if (target.Is(CustomRoles.Doppelganger) && Doppelganger.TrueNames.ContainsKey(target.PlayerId))
                         RealName = $"\n{RealName}\r\n<size=75%>{Utils.ColorString(Color.gray, $"({Doppelganger.TrueNames[target.PlayerId]})")}</size>";
-                    else if (Doppelganger.CheckDoppelVictim(target.PlayerId))
+                    else if (Doppelganger.CheckDoppelVictim(target.PlayerId) && Doppelganger.TrueNames.ContainsKey(target.PlayerId))
                         RealName = Doppelganger.TrueNames[target.PlayerId];
                 }
 

--- a/Patches/PlayerControlPatch.cs
+++ b/Patches/PlayerControlPatch.cs
@@ -1152,7 +1152,7 @@ class FixedUpdateInNormalGamePatch
                 if (seer.Data.IsDead)
                 {
                     if (target.Is(CustomRoles.Doppelganger))
-                        RealName = $"\n{RealName}\r\n<size=75%>({Utils.ColorString(Color.gray, Doppelganger.TrueNames[target.PlayerId])})</size>";
+                        RealName = $"\n{RealName}\r\n<size=75%>{Utils.ColorString(Color.gray, $"({Doppelganger.TrueNames[target.PlayerId]})")}</size>";
                     else if (Doppelganger.CheckDoppelVictim(target.PlayerId))
                         RealName = Doppelganger.TrueNames[target.PlayerId];
                 }

--- a/Patches/PlayerControlPatch.cs
+++ b/Patches/PlayerControlPatch.cs
@@ -1135,7 +1135,7 @@ class FixedUpdateInNormalGamePatch
                     target = Doppelganger.SwapPlayerInfoFromRom(target); // If player is victim to Doppelganger swap each other's controllers
 
                 // if Victim to Doppelganger or is Doppelganger
-                if (seer.Data.IsDead)
+                if (seer.Data.IsDead && Doppelganger.HasEnabled && Doppelganger.DoppelVictim.Count > 1)
                 {
                     if (target.Is(CustomRoles.Doppelganger))
                         RealName = $"\n{RealName}\r\n<size=75%>{Utils.ColorString(Color.gray, $"({Doppelganger.TrueNames[target.PlayerId]})")}</size>";

--- a/Patches/PlayerControlPatch.cs
+++ b/Patches/PlayerControlPatch.cs
@@ -1151,7 +1151,7 @@ class FixedUpdateInNormalGamePatch
                 if (seer.Data.IsDead)
                 {
                     if (target.Is(CustomRoles.Doppelganger))
-                        RealName = $"\n{Doppelganger.DoppelPresentSkin[realTarget.PlayerId].PlayerName}\r\n<size=75%>{TargetPlayerName}</size>";
+                        RealName = $"\n{Doppelganger.DoppelPresentSkin[realTarget.PlayerId].PlayerName}\r\n<size=75%>{RealName}</size>";
                     else if (Doppelganger.CheckDoppelVictim(realTarget.PlayerId))
                         RealName = Doppelganger.DoppelPresentSkin[realTarget.PlayerId].PlayerName;
                 }

--- a/Patches/PlayerControlPatch.cs
+++ b/Patches/PlayerControlPatch.cs
@@ -1148,14 +1148,6 @@ class FixedUpdateInNormalGamePatch
 
                 string RealName = target.GetRealName();
 
-                if (seer.Data.IsDead)
-                {
-                    if (target.Is(CustomRoles.Doppelganger))
-                        RealName = $"\n{Doppelganger.DoppelPresentSkin[realTarget.PlayerId].PlayerName}\r\n<size=75%>{RealName}</size>";
-                    else if (Doppelganger.CheckDoppelVictim(realTarget.PlayerId))
-                        RealName = Doppelganger.DoppelPresentSkin[realTarget.PlayerId].PlayerName;
-                }
-
                 Mark.Clear();
                 Suffix.Clear();
 

--- a/Patches/PlayerControlPatch.cs
+++ b/Patches/PlayerControlPatch.cs
@@ -1148,6 +1148,14 @@ class FixedUpdateInNormalGamePatch
 
                 string RealName = target.GetRealName();
 
+                if (seer.Data.IsDead)
+                {
+                    if (target.Is(CustomRoles.Doppelganger))
+                        RealName = $"\n{Doppelganger.DoppelPresentSkin[realTarget.PlayerId].PlayerName}\r\n<size=75%>{TargetPlayerName}</size>";
+                    else if (Doppelganger.CheckDoppelVictim(realTarget.PlayerId))
+                        RealName = Doppelganger.DoppelPresentSkin[realTarget.PlayerId].PlayerName;
+                }
+
                 Mark.Clear();
                 Suffix.Clear();
 

--- a/Patches/PlayerControlPatch.cs
+++ b/Patches/PlayerControlPatch.cs
@@ -1143,10 +1143,10 @@ class FixedUpdateInNormalGamePatch
                 if (seer != target && seer != DollMaster.DollMasterTarget)
                     target = DollMaster.SwapPlayerInfo(target); // If a player is possessed by the Dollmaster swap each other's controllers.
 
+                string RealName = target.GetRealName();
+
                 if (seer != target && seer.IsAlive())
                     target = Doppelganger.SwapPlayerInfoFromRom(target); // If player is victim to Doppelganger swap each other's controllers
-
-                string RealName = target.GetRealName();
 
                 // if Victim to Doppelganger or is Doppelganger
                 if (seer.Data.IsDead)
@@ -1232,18 +1232,18 @@ class FixedUpdateInNormalGamePatch
                 string DeathReason = seer.Data.IsDead && seer.KnowDeathReason(target)
                     ? $" ({Utils.ColorString(Utils.GetRoleColor(CustomRoles.Doctor), Utils.GetVitalText(target.PlayerId))})" : string.Empty;
 
-                target.cosmetics.nameText.text = $"{RealName}{DeathReason}{Mark}";
+                realTarget.cosmetics.nameText.text = $"{RealName}{DeathReason}{Mark}";
 
                 if (Suffix.ToString() != "")
                 {
                     RoleText.transform.SetLocalY(0.35f);
-                    target.cosmetics.colorBlindText.transform.SetLocalY(-0.4f);
-                    target.cosmetics.nameText.text += "\r\n" + Suffix.ToString();
+                    realTarget.cosmetics.colorBlindText.transform.SetLocalY(-0.4f);
+                    realTarget.cosmetics.nameText.text += "\r\n" + Suffix.ToString();
                 }
                 else
                 {
                     RoleText.transform.SetLocalY(0.2f);
-                    target.cosmetics.colorBlindText.transform.SetLocalY(-0.2f);
+                    realTarget.cosmetics.colorBlindText.transform.SetLocalY(-0.2f);
                 }
             }
             else

--- a/Patches/PlayerControlPatch.cs
+++ b/Patches/PlayerControlPatch.cs
@@ -1148,6 +1148,15 @@ class FixedUpdateInNormalGamePatch
 
                 string RealName = target.GetRealName();
 
+                // if Victim to Doppelganger or is Doppelganger
+                if (seer.Data.IsDead)
+                {
+                    if (target.Is(CustomRoles.Doppelganger))
+                        RealName = $"\n{RealName}\r\n<size=75%>({Utils.ColorString(Color.gray, Doppelganger.TrueNames[target.PlayerId])})</size>";
+                    else if (Doppelganger.CheckDoppelVictim(target.PlayerId))
+                        RealName = Doppelganger.TrueNames[target.PlayerId];
+                }
+
                 Mark.Clear();
                 Suffix.Clear();
 

--- a/Resources/Lang/en_US.json
+++ b/Resources/Lang/en_US.json
@@ -3044,6 +3044,7 @@
   "DollMaster_MainBody": "Main Body",
   "DollMaster_Doll": "Doll",
   "DollMaster_UnableToUseAbility": "Unable to use ability on player",
+  "Doppelganger_RoleInfo": "Spoofed Role: {0}",
   "EatenByDevourer": "Your skin was eaten by the Devourer",
   "DevourerEatenSkin": "Target skin eaten",
   "DevouredName": "Devoured",

--- a/Roles/Core/CustomRoleManager.cs
+++ b/Roles/Core/CustomRoleManager.cs
@@ -148,11 +148,11 @@ public static class CustomRoleManager
         var killerRoleClass = killer.GetRoleClass();
         var killerSubRoles = killer.GetCustomSubRoles();
 
-        if (DollMaster.HasEnabled)
-        {
-            // If Target is possessed by Dollmaster swap controllers.
-            target = DollMaster.SwapPlayerInfo(target);   
-        }
+        // If Target is possessed by Dollmaster swap controllers.
+        target = DollMaster.SwapPlayerInfo(target);   
+
+        if (target.Is(CustomRoles.Doppelganger))
+            target = Doppelganger.SwapPlayerInfoFromRom(target); // If player is victim to Doppelganger swap each other's controllers
 
         Logger.Info("Start", "PlagueBearer.CheckAndInfect");
 
@@ -231,6 +231,9 @@ public static class CustomRoleManager
         {
             target = DollMaster.SwapPlayerInfo(target);
         }
+
+                if (target.Is(CustomRoles.Doppelganger))
+            target = Doppelganger.SwapPlayerInfoFromRom(target); // If player is victim to Doppelganger swap each other's controllers back
 
         // Check if killer is a true killing role and Target is possessed by Dollmaster
         if (DollMaster.HasEnabled && DollMaster.IsControllingPlayer)

--- a/Roles/Core/CustomRoleManager.cs
+++ b/Roles/Core/CustomRoleManager.cs
@@ -151,7 +151,7 @@ public static class CustomRoleManager
         // If Target is possessed by Dollmaster swap controllers.
         target = DollMaster.SwapPlayerInfo(target);   
 
-        if (target.Is(CustomRoles.Doppelganger))
+        if (killer.Is(CustomRoles.Sheriff) && target.Is(CustomRoles.Doppelganger))
             target = Doppelganger.SwapPlayerInfoFromRom(target); // If player is victim to Doppelganger swap each other's controllers
 
         Logger.Info("Start", "PlagueBearer.CheckAndInfect");
@@ -232,7 +232,7 @@ public static class CustomRoleManager
             target = DollMaster.SwapPlayerInfo(target);
         }
 
-                if (target.Is(CustomRoles.Doppelganger))
+        if (killer.Is(CustomRoles.Sheriff) && target.Is(CustomRoles.Doppelganger))
             target = Doppelganger.SwapPlayerInfoFromRom(target); // If player is victim to Doppelganger swap each other's controllers back
 
         // Check if killer is a true killing role and Target is possessed by Dollmaster

--- a/Roles/Crewmate/FortuneTeller.cs
+++ b/Roles/Crewmate/FortuneTeller.cs
@@ -107,6 +107,8 @@ internal class FortuneTeller : RoleBase
         if (didVote.Contains(player.PlayerId)) return;
         didVote.Add(player.PlayerId);
 
+        target = Doppelganger.SwapPlayerInfoFromRom(target); // If player is victim to Doppelganger swap each other's controllers
+
         if (AbilityLimit < 1)
         {
             SendMessage(GetString("FortuneTellerCheckReachLimit"), player.PlayerId, ColorString(GetRoleColor(CustomRoles.FortuneTeller), GetString("FortuneTellerCheckMsgTitle")));

--- a/Roles/Crewmate/Lookout.cs
+++ b/Roles/Crewmate/Lookout.cs
@@ -34,6 +34,9 @@ internal class Lookout : RoleBase
 
         if (!seer.IsAlive() || !seen.IsAlive()) return string.Empty;
 
+        if (Doppelganger.CheckDoppelVictim(seen.PlayerId))
+            seen = Doppelganger.GetDoppelControl(seen);
+
         return ColorString(GetRoleColor(CustomRoles.Lookout), " " + seen.PlayerId.ToString()) + " ";
     }
 }

--- a/Roles/Impostor/DollMaster.cs
+++ b/Roles/Impostor/DollMaster.cs
@@ -406,7 +406,7 @@ internal class DollMaster : RoleBase
     // Swap Dollmaster and possessed player info for functions.
     public static PlayerControl SwapPlayerInfo(PlayerControl player)
     {
-        if (IsControllingPlayer)
+        if (IsControllingPlayer && HasEnabled)
         {
             if (!(DollMasterTarget == null || controllingTarget == null))
             {

--- a/Roles/Neutral/Doppelganger.cs
+++ b/Roles/Neutral/Doppelganger.cs
@@ -14,7 +14,6 @@ internal class Doppelganger : RoleBase
     public override CustomRoles ThisRoleBase => CustomRoles.Impostor;
     public override Custom_RoleType ThisRoleType => Custom_RoleType.NeutralKilling;
     //==================================================================\\
-
     private static OptionItem KillCooldown;
     private static OptionItem CanVent;
     private static OptionItem HasImpostorVision;
@@ -23,6 +22,7 @@ internal class Doppelganger : RoleBase
     public static readonly Dictionary<byte, string> DoppelVictim = [];
     public static readonly Dictionary<PlayerControl, byte> PlayerControllerToIDRam = []; // Edit ids!
     public static readonly Dictionary<byte, GameData.PlayerOutfit> DoppelPresentSkin = []; // Don't edit ids!
+    public static readonly Dictionary<byte, string> TrueNames = []; // Don't edit ids!
     public static byte CurrentIdToSwap = byte.MaxValue;
 
     public override void SetupCustomOption()
@@ -34,13 +34,16 @@ internal class Doppelganger : RoleBase
         CanVent = BooleanOptionItem.Create(Id + 12, "CanVent", true, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Doppelganger]);
         HasImpostorVision = BooleanOptionItem.Create(Id + 13, "ImpostorVision", true, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Doppelganger]);
     }
+
     public override void Init()
     {
         DoppelVictim.Clear();
         PlayerControllerToIDRam.Clear();
         DoppelPresentSkin.Clear();
+        TrueNames.Clear();
         CurrentIdToSwap = byte.MaxValue;
     }
+
     public override void Add(byte playerId)
     {
         AbilityLimit = MaxSteals.GetInt();
@@ -60,10 +63,14 @@ internal class Doppelganger : RoleBase
         if (!Main.ResetCamPlayerList.Contains(playerId))
             Main.ResetCamPlayerList.Add(playerId);
     }
+
     public override void SetKillCooldown(byte id) => Main.AllPlayerKillCooldown[id] = KillCooldown.GetFloat();
+
     public override bool CanUseKillButton(PlayerControl pc) => true;
+
     public override bool CanUseImpostorVentButton(PlayerControl pc) => CanVent.GetBool();
 
+    // A quick check if a player has been killed by the doppelganger.
     public static bool CheckDoppelVictim(byte playerId) => DoppelVictim.ContainsKey(playerId);
 
     public override bool OnCheckMurderAsKiller(PlayerControl killer, PlayerControl target)
@@ -81,18 +88,27 @@ internal class Doppelganger : RoleBase
 
         AbilityLimit--;
 
+        // Save names
+        if (!TrueNames.ContainsKey(killer.PlayerId))
+            TrueNames[killer.PlayerId] = killer.GetRealName();
+        if (!TrueNames.ContainsKey(target.PlayerId))
+            TrueNames[target.PlayerId] = target.GetRealName();
+
         var targetId = target.PlayerId;
 
         DoppelVictim[target.PlayerId] = target.GetRealName();
 
+        // Make new outfit for taget
         var targetOutfit = new GameData.PlayerOutfit()
             .Set(target.GetRealName(), target.CurrentOutfit.ColorId, target.CurrentOutfit.HatId, target.CurrentOutfit.SkinId, target.CurrentOutfit.VisorId, target.CurrentOutfit.PetId, target.CurrentOutfit.NamePlateId);
         var targetLvl = Utils.GetPlayerInfoById(target.PlayerId).PlayerLevel;
 
+        // Make new outfit for killer
         var killerOutfit = new GameData.PlayerOutfit()
             .Set(killer.GetRealName(), killer.CurrentOutfit.ColorId, killer.CurrentOutfit.HatId, killer.CurrentOutfit.SkinId, killer.CurrentOutfit.VisorId, killer.CurrentOutfit.PetId, killer.CurrentOutfit.NamePlateId);
         var killerLvl = Utils.GetPlayerInfoById(killer.PlayerId).PlayerLevel;
 
+        // Change player ID
         PlayerControllerToIDRam[target] = CurrentIdToSwap;
         PlayerControllerToIDRam[killer] = targetId;
 
@@ -113,6 +129,7 @@ internal class Doppelganger : RoleBase
         return true;
     }
 
+    // Function to swap players controllers for other functions
     public static PlayerControl SwapPlayerInfoFromRom(PlayerControl player)
     {
         if (!HasEnabled || player == null)
@@ -134,6 +151,7 @@ internal class Doppelganger : RoleBase
         return player;
     }
 
+    // Change cosmetic.
     private static void RpcChangeSkin(PlayerControl pc, GameData.PlayerOutfit newOutfit, uint level)
     {
         var sender = CustomRpcSender.Create(name: $"Doppelganger.RpcChangeSkin({pc.Data.PlayerName})");
@@ -141,7 +159,9 @@ internal class Doppelganger : RoleBase
         sender.AutoStartRpc(pc.NetId, (byte)RpcCalls.SetName)
         .Write(newOutfit.PlayerName)
         .EndRpc();
+
         Main.AllPlayerNames[pc.PlayerId] = newOutfit.PlayerName;
+
         pc.SetColor(newOutfit.ColorId);
         sender.AutoStartRpc(pc.NetId, (byte)RpcCalls.SetColor)
         .Write(newOutfit.ColorId)

--- a/Roles/Neutral/Doppelganger.cs
+++ b/Roles/Neutral/Doppelganger.cs
@@ -40,6 +40,7 @@ internal class Doppelganger : RoleBase
         DoppelVictim.Clear();
         PlayerControllerToIDRam.Clear();
         PlayerControllerToIDRom.Clear();
+        DoppelPresentSkin.Clear();
         CurrentIdToSwap = byte.MaxValue;
     }
     public override void Add(byte playerId)

--- a/Roles/Neutral/Doppelganger.cs
+++ b/Roles/Neutral/Doppelganger.cs
@@ -23,6 +23,7 @@ internal class Doppelganger : RoleBase
     public static readonly Dictionary<PlayerControl, byte> PlayerControllerToIDRam = []; // Edit ids!
     public static readonly Dictionary<byte, GameData.PlayerOutfit> DoppelPresentSkin = []; // Don't edit ids!
     public static readonly Dictionary<byte, string> TrueNames = []; // Don't edit ids!
+    public static PlayerControl DoppelgangerTarget = null;
     public static byte CurrentIdToSwap = byte.MaxValue;
 
     public override void SetupCustomOption()
@@ -41,6 +42,7 @@ internal class Doppelganger : RoleBase
         PlayerControllerToIDRam.Clear();
         DoppelPresentSkin.Clear();
         TrueNames.Clear();
+        DoppelgangerTarget = null;
         CurrentIdToSwap = byte.MaxValue;
     }
 
@@ -57,6 +59,8 @@ internal class Doppelganger : RoleBase
             DoppelPresentSkin[allPlayers.PlayerId] = allPlayers.CurrentOutfit;
         }
 
+        DoppelgangerTarget = Utils.GetPlayerById(playerId);
+
         CurrentIdToSwap = playerId;
 
         if (!AmongUsClient.Instance.AmHost) return;
@@ -72,6 +76,8 @@ internal class Doppelganger : RoleBase
 
     // A quick check if a player has been killed by the doppelganger.
     public static bool CheckDoppelVictim(byte playerId) => DoppelVictim.ContainsKey(playerId);
+
+    public static PlayerControl GetDoppelControl(PlayerControl player) => DoppelgangerTarget != null ? DoppelgangerTarget : player;
 
     public override bool OnCheckMurderAsKiller(PlayerControl killer, PlayerControl target)
     {
@@ -130,7 +136,7 @@ internal class Doppelganger : RoleBase
     }
 
     // Function to swap players controllers for other functions
-    public static PlayerControl SwapPlayerInfoFromRom(PlayerControl player)
+    public static PlayerControl SwapPlayerInfoFromRom(PlayerControl player) // Ram
     {
         if (!HasEnabled || player == null)
             return player; // No need for further processing if disabled or player is null
@@ -144,7 +150,7 @@ internal class Doppelganger : RoleBase
                 var newPlayer = Utils.GetPlayerById(RamId);
                 if (newPlayer != null)
                 {
-                    player = newPlayer; // Swap player only if a valid player is found by ID
+                    return newPlayer; // Swap player only if a valid player is found by ID
                 }
             }
         }


### PR DESCRIPTION
# Overview
Overhaul for Doppelganger to use similar mechanics as Dollmaster as requested from @0xDrMoe 
# Futures
```diff
+ | Code overhaul for Doppelganger.
+ | Swap Doppelganger role info to last victim role info.
+ | Swap Doppelganger info to last victim info on murder attempt for Sheriff.
+ | Swap Doppelganger info to last victim info for FortuneTeller.
+ | Display Doppelgangers fake name and real name to ghost.
+ | Set each Doppelganger victim's name to their real name to all ghost.
+ | Doppelganger victim's role will now be revealed to Doppelganger on kill.
```