### PR TITLE
Display Role Info For Vanilla on intro

### DIFF
--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -1661,12 +1661,15 @@ public static class Utils
                 //Get role info font size based on the length of the role info
                 static int GetInfoSize(string RoleInfo)
                 {
-                    var BaseFontSize = 200;
-                    if (RoleInfo.Length > 30)
-                        BaseFontSize = 150;
-                    if (RoleInfo.Length > 60)
-                        BaseFontSize = 100;
+                    RoleInfo = Regex.Replace(RoleInfo, "<[^>]*>", "");
+                    RoleInfo = Regex.Replace(RoleInfo, "{[^>]*}", "");
 
+                    var BaseFontSize = 275;
+                    int BaseFontSizeMin = 100;
+
+                    BaseFontSize -= 3 * RoleInfo.Length;
+                    if (BaseFontSize < BaseFontSizeMin)
+                        BaseFontSize = BaseFontSizeMin;
                     return BaseFontSize;
                 }
 
@@ -1686,7 +1689,7 @@ public static class Utils
                 if (!seer.GetCustomRole().IsDesyncRole())
                 {
                     SelfTeamName = string.Empty;
-                    RoleNameUp = "<size=625%>\n</size>";
+                    RoleNameUp = "<size=565%>\n</size>";
                     RoleInfo = $"<size=50%>\n</size><size={GetInfoSize(seer.GetRoleInfo())}%>{Font}{ColorString(seer.GetRoleColor(), seer.GetRoleInfo())}</font></size>";
                 }
 

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -1770,21 +1770,21 @@ public static class Utils
 
                 string SeerRealName = seer.GetRealName(isForMeeting);
 
+                bool IsDisplayInfo = false;
                 if (MeetingStates.FirstMeeting && Options.ChangeNameToRoleInfo.GetBool() && !isForMeeting && Options.CurrentGameMode != CustomGameMode.FFA)
                 {
+                    IsDisplayInfo = true;
                     var SeerRoleInfo = seer.GetRoleInfo();
 
-                    if (seerRole.IsImpostor())
-                        SeerRealName = $"<size=110%><color=#ff1919>" + GetString("YouAreImpostor") + $"</color></size>\n<size=130%>" + SeerRoleInfo + $"</size>";
+                    string RoleText = string.Empty;
+                    string Font = "<font=\"VCR SDF\" material=\"VCR Black Outline\">";
 
-                    else if (seerRole.IsCrewmate() && !seer.Is(CustomRoles.Madmate))
-                        SeerRealName = $"<size=110%><color=#8cffff>" + GetString("YouAreCrewmate") + $"</color></size>\n" + SeerRoleInfo;
+                    if (seerRole.IsImpostor()) { RoleText = ColorString(GetTeamColor(seer), GetString("TeamImpostor")); }
+                    else if (seerRole.IsCrewmate()) { RoleText = ColorString(GetTeamColor(seer), GetString("TeamCrewmate")); }
+                    else if (seerRole.IsNeutral()) { RoleText = ColorString(GetTeamColor(seer), GetString("TeamNeutral")); }
+                    else if (seerRole.IsMadmate()) { RoleText = ColorString(GetTeamColor(seer), GetString("TeamMadmate")); }
 
-                    else if (seerRole.IsNeutral() && !seerRole.IsMadmate())
-                        SeerRealName = $"<size=110%><color=#7f8c8d>" + GetString("YouAreNeutral") + $"</color></size>\n<size=130%>" + SeerRoleInfo + $"</size>";
-
-                    else if (seerRole.IsMadmate() || seerRole == CustomRoles.Madmate)
-                        SeerRealName = $"<size=110%><color=#ff1919>" + GetString("YouAreMadmate") + $"</color></size>\n<size=130%>" + SeerRoleInfo + $"</size>";
+                    SeerRealName = $"{SeerRealName}<size=600%>\n \n</size><size=150%>{Font}{ColorString(seer.GetRoleColor(), RoleText)}</size>\n<size=75%>{ColorString(seer.GetRoleColor(), seer.GetRoleInfo())}</size></font>";
                 }
 
                 // ====== Combine SelfRoleName, SelfTaskText, SelfName, SelfDeathReason for seer ======
@@ -1823,7 +1823,10 @@ public static class Utils
                         SelfName = $"<size={fontSize}>{SelfTaskText}</size>\r\n{SelfName}";
                         break;
                     default:
-                        SelfName = SelfRoleName + "\r\n" + SelfName;
+                        if (!IsDisplayInfo)
+                            SelfName = SelfRoleName + "\r\n" + SelfName;
+                        else
+                            SelfName = "<size=350%>\n \n</size>" + SelfRoleName + "\r\n" + SelfName;
                         break;
                 }
                 SelfName += SelfSuffix.Length == 0 ? string.Empty : "\r\n " + SelfSuffix.ToString();

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -1662,7 +1662,7 @@ public static class Utils
                 static int GetInfoSize(string RoleInfo)
                 {
                     RoleInfo = Regex.Replace(RoleInfo, "<[^>]*>", "");
-                    RoleInfo = Regex.Replace(RoleInfo, "{[^>]*}", "");
+                    RoleInfo = Regex.Replace(RoleInfo, "{[^}]*}", "");
 
                     var BaseFontSize = 275;
                     int BaseFontSizeMin = 100;

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -1656,6 +1656,8 @@ public static class Utils
             if (seer.IsModClient()) continue;
 
             // During intro scene to set team name and role info for non-modded clients and skip the rest.
+            // Note: When Neutral is based on the Crewmate role then it is impossible to display the info for it
+            // If not a Desync Role remove team display
             if (SetUpRoleTextPatch.IsInIntro)
             {
                 //Get role info font size based on the length of the role info
@@ -1683,9 +1685,6 @@ public static class Utils
                 string RoleInfo = $"<size=25%>\n</size><size={GetInfoSize(seer.GetRoleInfo())}%>{Font}{ColorString(seer.GetRoleColor(), seer.GetRoleInfo())}</font></size>";
                 string RoleNameUp = "<size=1350%>\n\n</size>";
 
-                // Only for desync role, because their team is always shown as Impostor even though they may be in a Crewmate or Neutrals team
-                // Note: When Neutral is based on the Crewmate role then it is impossible to display the real team for it
-                // If not a Desync Role remove team display
                 if (!seer.GetCustomRole().IsDesyncRole())
                 {
                     SelfTeamName = string.Empty;
@@ -1770,6 +1769,13 @@ public static class Utils
 
                 string SeerRealName = seer.GetRealName(isForMeeting);
 
+                // ====== Combine SelfRoleName, SelfTaskText, SelfName, SelfDeathReason for seer ======
+
+                string SelfTaskText = GetProgressText(seer);
+                string SelfRoleName = $"<size={fontSize}>{seer.GetDisplayRoleAndSubName(seer, false)}{SelfTaskText}</size>";
+                string SelfDeathReason = seer.KnowDeathReason(seer) ? $"({ColorString(GetRoleColor(CustomRoles.Doctor), GetVitalText(seer.PlayerId))})" : string.Empty;
+                string SelfName = $"{ColorString(seer.GetRoleColor(), SeerRealName)}{SelfDeathReason}{SelfMark}";
+
                 bool IsDisplayInfo = false;
                 if (MeetingStates.FirstMeeting && Options.ChangeNameToRoleInfo.GetBool() && !isForMeeting && Options.CurrentGameMode != CustomGameMode.FFA)
                 {
@@ -1784,18 +1790,14 @@ public static class Utils
                     else if (seerRole.IsNeutral()) { RoleText = ColorString(GetTeamColor(seer), GetString("TeamNeutral")); }
                     else if (seerRole.IsMadmate()) { RoleText = ColorString(GetTeamColor(seer), GetString("TeamMadmate")); }
 
-                    SeerRealName = $"{SeerRealName}<size=600%>\n \n</size><size=150%>{Font}{ColorString(seer.GetRoleColor(), RoleText)}</size>\n<size=75%>{ColorString(seer.GetRoleColor(), seer.GetRoleInfo())}</size></font>";
+                    SelfName = $"{SelfName}<size=600%>\n \n</size><size=150%>{Font}{ColorString(seer.GetRoleColor(), RoleText)}</size>\n<size=75%>{ColorString(seer.GetRoleColor(), seer.GetRoleInfo())}</size></font>\n";
                 }
 
-                // ====== Combine SelfRoleName, SelfTaskText, SelfName, SelfDeathReason for seer ======
-
-                string SelfTaskText = GetProgressText(seer);
-                string SelfRoleName = $"<size={fontSize}>{seer.GetDisplayRoleAndSubName(seer, false)}{SelfTaskText}</size>";
-                string SelfDeathReason = seer.KnowDeathReason(seer) ? $"({ColorString(GetRoleColor(CustomRoles.Doctor), GetVitalText(seer.PlayerId))})" : string.Empty;
-                string SelfName = $"{ColorString(seer.GetRoleColor(), SeerRealName)}{SelfDeathReason}{SelfMark}";
-
                 if (NameNotifyManager.GetNameNotify(seer, out var name))
+                {
                     SelfName = name;
+                    IsDisplayInfo = false;
+                }
 
                 if (Pelican.HasEnabled && Pelican.IsEaten(seer.PlayerId))
                     SelfName = $"{ColorString(GetRoleColor(CustomRoles.Pelican), GetString("EatenByPelican"))}";
@@ -1826,7 +1828,7 @@ public static class Utils
                         if (!IsDisplayInfo)
                             SelfName = SelfRoleName + "\r\n" + SelfName;
                         else
-                            SelfName = "<size=350%>\n \n</size>" + SelfRoleName + "\r\n" + SelfName;
+                            SelfName = "<size=425%>\n \n</size>" + SelfRoleName + "\r\n" + SelfName;
                         break;
                 }
                 SelfName += SelfSuffix.Length == 0 ? string.Empty : "\r\n " + SelfSuffix.ToString();


### PR DESCRIPTION
# Overview
Made it where it displays players role, add-ons, and role info on intro scene for non-modded clients.
![Display1](https://github.com/0xDrMoe/TownofHost-Enhanced/assets/83262852/3a574eef-9c13-42ed-ac60-6c909aa7e1bb)
![Display2](https://github.com/0xDrMoe/TownofHost-Enhanced/assets/83262852/19e25aa1-5e56-4475-a6fb-78e87e912dd4)

Additionally I revamped the visuals for the "Show Role Info to Unmodded Clients Round 1" setting.
![RoleInfo](https://github.com/0xDrMoe/TownofHost-Enhanced/assets/83262852/5c183747-42c4-4b39-ad88-34b86f06dc37)

## Futures:
```diff
+ | Display Role for Vanilla clients on intro.
+ | Display Addons for Vanilla clients on intro.
+ | Display Role Info for Vanilla clients on intro.
+ | Automatic font size based on role info length.
+ | Visual revamp for "Show Role Info to Unmodded Clients Round 1" setting.
```