### PR TITLE
Players Know All Roles When Game End

### DIFF
--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -752,7 +752,7 @@ static class ExtendedPlayerControl
 
     public static bool KnowRoleTarget(PlayerControl seer, PlayerControl target)
     {
-        if (Options.CurrentGameMode == CustomGameMode.FFA) return true;
+        if (Options.CurrentGameMode == CustomGameMode.FFA || GameEndCheckerForNormal.ShowAllRolesWhenGameEnd) return true;
         else if (seer.Is(CustomRoles.GM) || target.Is(CustomRoles.GM) || (PlayerControl.LocalPlayer.PlayerId == seer.PlayerId && Main.GodMode.Value)) return true;
         else if (Main.VisibleTasksCount && !seer.IsAlive() && Options.GhostCanSeeOtherRoles.GetBool()) return true;
         else if (Options.SeeEjectedRolesInMeeting.GetBool() && Main.PlayerStates[target.PlayerId].deathReason == PlayerState.DeathReason.Vote) return true;

--- a/Patches/CheckGameEndPatch.cs
+++ b/Patches/CheckGameEndPatch.cs
@@ -49,7 +49,7 @@ class GameEndCheckerForNormal
         if (CustomWinnerHolder.WinnerTeam != CustomWinner.Default)
         {
             // Clear all Notice players 
-            NameNotifyManager.Notice.Clear();
+            NameNotifyManager.Reset();
 
             // Reset Camouflage
             Main.AllPlayerControls.Do(pc => Camouflage.RpcSetSkin(pc, ForceRevert: true, RevertToDefault: true, GameEnd: true));
@@ -445,7 +445,7 @@ class GameEndCheckerForNormal
             Main.AllPlayerControls.Where(pc => pc.Is(CustomRoles.SchrodingersCat)).ToList().ForEach(SchrodingersCat.SchrodingerWinCondition);
 
             ShipStatus.Instance.enabled = false;
-            // When crewmates win, show as impostor win. for displaying all names players
+            // When crewmates win, show as impostor win, for displaying all names players
             reason = reason is GameOverReason.HumansByVote or GameOverReason.HumansByTask ? GameOverReason.ImpostorByVote : reason;
             StartEndGame(reason);
             predicate = null;

--- a/Patches/CheckGameEndPatch.cs
+++ b/Patches/CheckGameEndPatch.cs
@@ -15,6 +15,8 @@ namespace TOHE;
 class GameEndCheckerForNormal
 {
     private static GameEndPredicate predicate;
+    public static bool ShowAllRolesWhenGameEnd = false;
+
     public static bool Prefix()
     {
         if (!AmongUsClient.Instance.AmHost) return true;
@@ -52,8 +54,11 @@ class GameEndCheckerForNormal
             // Reset Camouflage
             Main.AllPlayerControls.Do(pc => Camouflage.RpcSetSkin(pc, ForceRevert: true, RevertToDefault: true, GameEnd: true));
 
+            // Show all roles
+            ShowAllRolesWhenGameEnd = true;
+
             // Update all Notify Roles
-            Utils.DoNotifyRoles(ForceLoop: true);
+            Utils.DoNotifyRoles(ForceLoop: true, NoCache: true);
 
             if (reason == GameOverReason.ImpostorBySabotage && (CustomRoles.Jackal.RoleExist() || CustomRoles.Sidekick.RoleExist()) && Jackal.CanWinBySabotageWhenNoImpAlive.GetBool() && !Main.AllAlivePlayerControls.Any(x => x.GetCustomRole().IsImpostorTeam()))
             {
@@ -511,6 +516,9 @@ class GameEndCheckerForNormal
             // Delay to ensure that the end of the game is delivered at the end of the game
             yield return new WaitForSeconds(EndGameDelay);
         }
+
+        // Update all Notify Roles
+        Utils.DoNotifyRoles(ForceLoop: true, NoCache: true);
 
         // Start End Game
         GameManager.Instance.RpcEndGame(reason, false);

--- a/Patches/CheckGameEndPatch.cs
+++ b/Patches/CheckGameEndPatch.cs
@@ -445,6 +445,7 @@ class GameEndCheckerForNormal
             Main.AllPlayerControls.Where(pc => pc.Is(CustomRoles.SchrodingersCat)).ToList().ForEach(SchrodingersCat.SchrodingerWinCondition);
 
             ShipStatus.Instance.enabled = false;
+            reason = reason is GameOverReason.HumansByVote or GameOverReason.HumansByTask ? GameOverReason.ImpostorByVote : reason;
             StartEndGame(reason);
             predicate = null;
         }

--- a/Patches/CheckGameEndPatch.cs
+++ b/Patches/CheckGameEndPatch.cs
@@ -445,6 +445,7 @@ class GameEndCheckerForNormal
             Main.AllPlayerControls.Where(pc => pc.Is(CustomRoles.SchrodingersCat)).ToList().ForEach(SchrodingersCat.SchrodingerWinCondition);
 
             ShipStatus.Instance.enabled = false;
+            // When crewmates win, show as impostor win. for displaying all names players
             reason = reason is GameOverReason.HumansByVote or GameOverReason.HumansByTask ? GameOverReason.ImpostorByVote : reason;
             StartEndGame(reason);
             predicate = null;

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -74,6 +74,7 @@ internal class ChangeRoleSettings
             Main.MeetingsPassed = 0;
             Main.MeetingIsStarted = false;
             Main.introDestroyed = false;
+            GameEndCheckerForNormal.ShowAllRolesWhenGameEnd = false;
 
             ChatManager.ResetHistory();
             ReportDeadBodyPatch.CanReport = [];


### PR DESCRIPTION
![image](https://github.com/0xDrMoe/TownofHost-Enhanced/assets/104814436/eedb5c91-be90-4485-b6fe-f285606465c3)


Note: does not always work, for example, when crewmates win, the player names are not displayed at all

![image](https://github.com/0xDrMoe/TownofHost-Enhanced/assets/104814436/b0d9e261-7fb0-419a-a6ac-1146cf9af744)
