### PR TITLE
Doppelganger Host Fixes

### DIFF
--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -1073,11 +1073,6 @@ static class ExtendedPlayerControl
         {
             return false;
         }
-        
-        // If doppelganger appears as player return true
-        // Note: Needs to be tested for any buggy outcomes.
-        if (Doppelganger.CheckDoppelVictim(target.PlayerId) && target.PlayerId == Doppelganger.CurrentIdToSwap)
-            return true;
 
         //if the target status is alive
         return !Main.PlayerStates.TryGetValue(target.PlayerId, out var playerState) || !playerState.IsDead;


### PR DESCRIPTION
Fixed issue with system messages and roles not showing to the host when they are dead after being killed by the doppelganger, caused by unused code making the IsAlive statement return true.