### PR TITLE
New setting for Doppelganger

### DIFF
--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -2012,6 +2012,10 @@ public static class Utils
                         string TargetName = $"{TargetRoleText}{TargetPlayerName}{TargetDeathReason}{TargetMark}{TargetSuffix}";
                         //TargetName += TargetSuffix.ToString() == "" ? "" : ("\r\n" + TargetSuffix.ToString());
 
+                        // If Doppelganger.CurrentVictimCanSeeRolesAsDead is disabled and player is the most recent victim from the doppelganger hide role information for player.
+                        if (seer.Data.IsDead && seer != target && !target.Data.IsDead && !target.Is(CustomRoles.Doppelganger) && !Doppelganger.CurrentVictimCanSeeRolesAsDead.GetBool() && Doppelganger.CurrentIdToSwap == seer.PlayerId)
+                            TargetName = target.GetRealName();
+
                         realTarget.RpcSetNamePrivate(TargetName, true, seer, force: NoCache);
                     }
                 }

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -925,6 +925,17 @@ class MeetingHudStartPatch
                 suffixBuilder.Append(myRole.GetSuffix(PlayerControl.LocalPlayer, pc, isForMeeting: true));
             }
             suffixBuilder.Append(CustomRoleManager.GetSuffixOthers(PlayerControl.LocalPlayer, pc, isForMeeting: true));
+
+            // If Doppelganger.CurrentVictimCanSeeRolesAsDead is disabled and player is the most recent victim from the doppelganger hide role information for player.
+            var player = PlayerControl.LocalPlayer;
+            var target = Utils.GetPlayerById(pva.TargetPlayerId);
+            if (target != null && player != null)
+            {
+                if (player.Data.IsDead && player != target && !target.Data.IsDead && !target.Is(CustomRoles.Doppelganger) && !Doppelganger.CurrentVictimCanSeeRolesAsDead.GetBool() && Doppelganger.CurrentIdToSwap == player.PlayerId)
+                {
+                    roleTextMeeting.text = string.Empty;
+                }
+            }
             
             if (suffixBuilder.Length > 0)
             {
@@ -1077,6 +1088,13 @@ class MeetingHudStartPatch
                 }
             }
             //add checks for both seer and target's subrole, maybe one day we can use them...
+
+            // If Doppelganger.CurrentVictimCanSeeRolesAsDead is disabled and player is the most recent victim from the doppelganger hide role information for player.
+            if (seer.Data.IsDead && seer != target && !target.Data.IsDead && !target.Is(CustomRoles.Doppelganger) && !Doppelganger.CurrentVictimCanSeeRolesAsDead.GetBool() && Doppelganger.CurrentIdToSwap == seer.PlayerId)
+            {
+                pva.NameText.text = target.GetRealName();
+                sb.Clear();
+            }
 
             pva.NameText.text += sb.ToString();
             pva.ColorBlindName.transform.localPosition -= new Vector3(1.35f, 0f, 0f);

--- a/Patches/PlayerControlPatch.cs
+++ b/Patches/PlayerControlPatch.cs
@@ -1232,6 +1232,16 @@ class FixedUpdateInNormalGamePatch
                 string DeathReason = seer.Data.IsDead && seer.KnowDeathReason(target)
                     ? $" ({Utils.ColorString(Utils.GetRoleColor(CustomRoles.Doctor), Utils.GetVitalText(target.PlayerId))})" : string.Empty;
 
+                // If Doppelganger.CurrentVictimCanSeeRolesAsDead is disabled and player is the most recent victim from the doppelganger hide role information for player.
+                if (seer.Data.IsDead && seer != target && !target.Data.IsDead && !target.Is(CustomRoles.Doppelganger) && !Doppelganger.CurrentVictimCanSeeRolesAsDead.GetBool() && Doppelganger.CurrentIdToSwap == seer.PlayerId)
+                {
+                    RealName = target.GetRealName();
+                    DeathReason = string.Empty;
+                    RoleText.text = string.Empty;
+                    Suffix.Clear();
+                    Mark.Clear();
+                }
+
                 realTarget.cosmetics.nameText.text = $"{RealName}{DeathReason}{Mark}";
 
                 if (Suffix.ToString() != "")

--- a/Resources/Lang/en_US.json
+++ b/Resources/Lang/en_US.json
@@ -2810,6 +2810,7 @@
   "BanditStealCooldown": "Steal cooldown",
 
   "DoppelMaxSteals": "Maximum Steals",
+  "DoppelCurrentVictimCanSeeRolesAsDead": "Last victim can see role and add-on info of alive players as ghost",
 
   "NecromancerRevengeTime": "Necromancy time",
   "NecromancerRevenge": "You have {0}s to kill <color=#ff1919>{1}</color>",

--- a/Roles/Neutral/Doppelganger.cs
+++ b/Roles/Neutral/Doppelganger.cs
@@ -30,10 +30,11 @@ internal class Doppelganger : RoleBase
     {
         SetupSingleRoleOptions(Id, TabGroup.NeutralRoles, CustomRoles.Doppelganger, 1, zeroOne: false);
         MaxSteals = IntegerOptionItem.Create(Id + 10, "DoppelMaxSteals", new(1, 14, 1), 9, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Doppelganger]);
-        KillCooldown = FloatOptionItem.Create(Id + 11, "KillCooldown", new(0f, 180f, 2.5f), 20f, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Doppelganger])
+        CurrentVictimCanSeeRolesAsDead = BooleanOptionItem.Create(Id + 11, "DoppelCurrentVictimCanSeeRolesAsDead", false, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Doppelganger]);
+        KillCooldown = FloatOptionItem.Create(Id + 12, "KillCooldown", new(0f, 180f, 2.5f), 20f, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Doppelganger])
             .SetValueFormat(OptionFormat.Seconds);
-        CanVent = BooleanOptionItem.Create(Id + 12, "CanVent", true, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Doppelganger]);
-        HasImpostorVision = BooleanOptionItem.Create(Id + 13, "ImpostorVision", true, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Doppelganger]);
+        CanVent = BooleanOptionItem.Create(Id + 13, "CanVent", true, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Doppelganger]);
+        HasImpostorVision = BooleanOptionItem.Create(Id + 14, "ImpostorVision", true, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Doppelganger]);
     }
 
     public override void Init()


### PR DESCRIPTION
# Overview
Added a new setting for Doppelganger that makes it where for the last victim which is dead, it hides role and add-on information of alive players.
## Futures:
```diff
+ Added new Doppelganger setting
```