### PR TITLE
Rework Lovers win condition check

### DIFF
--- a/Modules/OptionHolder.cs
+++ b/Modules/OptionHolder.cs
@@ -489,6 +489,8 @@ public static class Options
     public static OptionItem LoverSpawnChances;
     public static OptionItem LoverKnowRoles;
     public static OptionItem LoverSuicide;
+    public static OptionItem LoversStealWinWhenAlive;
+    public static OptionItem LoversFollowWin;
     public static OptionItem ImpCanBeInLove;
     public static OptionItem CrewCanBeInLove;
     public static OptionItem NeutralCanBeInLove;
@@ -1912,6 +1914,14 @@ public static class Options
             .SetGameMode(customGameMode);
 
         LoverSuicide = BooleanOptionItem.Create(id + 3, "LoverSuicide", true, TabGroup.Addons, false)
+        .SetParent(spawnOption)
+            .SetGameMode(customGameMode);
+
+        LoversStealWinWhenAlive = BooleanOptionItem.Create(id + 8, "LoversStealWinWhenAlive", true, TabGroup.Addons, false)
+        .SetParent(spawnOption)
+            .SetGameMode(customGameMode);
+
+        LoversFollowWin = BooleanOptionItem.Create(id + 9, "LoversFollowWin", false, TabGroup.Addons, false)
         .SetParent(spawnOption)
             .SetGameMode(customGameMode);
 

--- a/Resources/Lang/en_US.json
+++ b/Resources/Lang/en_US.json
@@ -1371,7 +1371,7 @@
   "VampireActionMode": "Action Mode",
   "Vampire_OnlyBites": "Only Bites",
 
-  "KamikazeControversialSymbol":  "Use controversial symbol",
+  "KamikazeControversialSymbol": "Use controversial symbol",
 
   "MareAddSpeedInLightsOut": "Additional Speed During Lights Out",
   "MareKillCooldownInLightsOut": "Kill Cooldown During Lights Out",
@@ -1468,6 +1468,8 @@
   "LawyerVision": "<color=#008080>Lawyer</color> Vision",
   "FlashSpeed": "<color=#ff8400>Flash</color> Speed",
   "LoverSuicide": "<color=#ff9ace>Lovers</color> die together",
+  "LoversStealWinWhenAlive": "<color=#ff9ace>Lovers</color> steal the win when alive",
+  "LoversFollowWin": "<color=#ff9ace>Lovers</color> follow the winner team when died",
   "NumberOfLovers": "Number of <color=#ff9ace>Lover Pairs</color> (x2 members)",
   "LoverKnowRoles": "<color=#ff9ace>Lovers</color> know the roles of each other",
   "TrapperBlockMoveTime": "Freeze time",
@@ -3162,7 +3164,7 @@
   "GhastlyNotUrTarget": "That is not your target",
   "GhastlyYouvePosses": "You've Been Possessed!",
   "GhastlyPossessedUser": "You have possessed: {0}",
-  "GhastlyExpired":  "{0} is no longer possessed",
+  "GhastlyExpired": "{0} is no longer possessed",
 
   "TasksMarkPerRound": "Number of tasks that can be marked in one round",
   "TaskinatorBombPlanted": "Bomb has been planted",


### PR DESCRIPTION
The current lovers win condition is very dumb and unfair.
Lovers can just give up struggling to survive and wait for one of their team to win

I will work to try to return the original lovers win condition while allow settings to current follow win

Also gonna rework the win check when lovers are counted as different team type and game wont end
Like when 1 imps and 2 crews, imp and a crew are lovers

