### PR TITLE
Rename some harmony functions and enums to bypass Dotfuscator renaming

### DIFF
--- a/Modules/DoorsReset.cs
+++ b/Modules/DoorsReset.cs
@@ -3,7 +3,7 @@ namespace TOHE.Modules;
 public static class DoorsReset
 {
     private static bool isEnabled = false;
-    private static ResetMode mode;
+    private static ResetModeList mode;
     private static DoorsSystemType DoorsSystem => ShipStatus.Instance.Systems.TryGetValue(SystemTypes.Doors, out var system) ? system.TryCast<DoorsSystemType>() : null;
     private static readonly LogHandler logger = Logger.Handler(nameof(DoorsReset));
 
@@ -21,7 +21,7 @@ public static class DoorsReset
             return;
         }
         isEnabled = Options.ResetDoorsEveryTurns.GetBool();
-        mode = (ResetMode)Options.DoorsResetMode.GetValue();
+        mode = (ResetModeList)Options.DoorsResetMode.GetValue();
         Logger.Info($"initialization: [ {isEnabled}, {mode} ]", "Reset Doors");
     }
 
@@ -36,9 +36,9 @@ public static class DoorsReset
 
         switch (mode)
         {
-            case ResetMode.AllOpen: OpenAllDoors(); break;
-            case ResetMode.AllClosed: CloseAllDoors(); break;
-            case ResetMode.RandomByDoor: OpenOrCloseAllDoorsRandomly(); break;
+            case ResetModeList.AllOpen: OpenAllDoors(); break;
+            case ResetModeList.AllClosed: CloseAllDoors(); break;
+            case ResetModeList.RandomByDoor: OpenOrCloseAllDoorsRandomly(); break;
             default: Logger.Warn($"Invalid Reset Doors Mode: {mode}", "Reset Doors"); break;
         }
     }
@@ -89,5 +89,5 @@ public static class DoorsReset
         return door.Room is not (SystemTypes.Lounge or SystemTypes.Decontamination);
     }
 
-    public enum ResetMode { AllOpen, AllClosed, RandomByDoor, }
+    public enum ResetModeList { AllOpen, AllClosed, RandomByDoor, }
 }

--- a/Modules/ModUpdater.cs
+++ b/Modules/ModUpdater.cs
@@ -31,7 +31,7 @@ public class ModUpdater
     public static PassiveButton updateButton;
 
     [HarmonyPatch(typeof(MainMenuManager), nameof(MainMenuManager.Start)), HarmonyPostfix, HarmonyPriority(Priority.VeryLow)]
-    public static void Start_Prefix(/*MainMenuManager __instance*/)
+    public static void Start_Postfix(/*MainMenuManager __instance*/)
     {
         ResetUpdateButton();
         if (isChecked) return;

--- a/Modules/OptionHolder.cs
+++ b/Modules/OptionHolder.cs
@@ -1320,7 +1320,7 @@ public static class Options
             .SetGameMode(CustomGameMode.Standard)
             .SetColor(new Color32(19, 188, 233, byte.MaxValue));
         // Reset Doors Mode
-        DoorsResetMode = StringOptionItem.Create(60501, "DoorsResetMode", EnumHelper.GetAllNames<DoorsReset.ResetMode>(), 2, TabGroup.GameSettings, false)
+        DoorsResetMode = StringOptionItem.Create(60501, "DoorsResetMode", EnumHelper.GetAllNames<DoorsReset.ResetModeList>(), 2, TabGroup.GameSettings, false)
             .SetParent(ResetDoorsEveryTurns)
             .SetColor(new Color32(19, 188, 233, byte.MaxValue));
         // Change decontamination time on MiraHQ/Polus

--- a/Patches/AnnouncementPatch.cs
+++ b/Patches/AnnouncementPatch.cs
@@ -55,7 +55,7 @@ public class ModNews
     }
 
     [HarmonyPatch(typeof(AnnouncementPopUp), nameof(AnnouncementPopUp.Init)), HarmonyPostfix]
-    public static void Initialize(ref Il2CppSystem.Collections.IEnumerator __result)
+    public static void Initialize_Postfix(ref Il2CppSystem.Collections.IEnumerator __result)
     {
         static IEnumerator FetchBlacklist()
         {
@@ -110,7 +110,7 @@ public class ModNews
 
 
     [HarmonyPatch(typeof(PlayerAnnouncementData), nameof(PlayerAnnouncementData.SetAnnouncements)), HarmonyPrefix]
-    public static bool SetModAnnouncements(PlayerAnnouncementData __instance, [HarmonyArgument(0)] ref Il2CppReferenceArray<Announcement> aRange)
+    public static bool SetModAnnouncements_Prefix(PlayerAnnouncementData __instance, [HarmonyArgument(0)] ref Il2CppReferenceArray<Announcement> aRange)
     {
         Logger.Info("AllModNews:" + AllModNews.Count, "ModNews");
         AllModNews.Sort((a1, a2) => { return DateTime.Compare(DateTime.Parse(a2.Date), DateTime.Parse(a1.Date)); });
@@ -133,7 +133,7 @@ public class ModNews
 
 
     [HarmonyPatch(typeof(AnnouncementPanel), nameof(AnnouncementPanel.SetUp)), HarmonyPostfix]
-    public static void SetUpPanel(AnnouncementPanel __instance, [HarmonyArgument(0)] Announcement announcement)
+    public static void SetUpPanel_Postfix(AnnouncementPanel __instance, [HarmonyArgument(0)] Announcement announcement)
     {
         if (announcement.Number < 100000) return;
         var obj = new GameObject("ModLabel");

--- a/Patches/AprilFoolsModePatch.cs
+++ b/Patches/AprilFoolsModePatch.cs
@@ -91,7 +91,7 @@ public static class LongBoiPatches
 {
     [HarmonyPatch(nameof(LongBoiPlayerBody.Awake))]
     [HarmonyPrefix]
-    public static bool LongBoyAwake_Patch(LongBoiPlayerBody __instance)
+    public static bool LongBoyAwake_Prefix(LongBoiPlayerBody __instance)
     {
         //Fixes base-game layer issues
         __instance.cosmeticLayer.OnSetBodyAsGhost += (Action)__instance.SetPoolableGhost;
@@ -103,7 +103,7 @@ public static class LongBoiPatches
 
     [HarmonyPatch(nameof(LongBoiPlayerBody.Start))]
     [HarmonyPrefix]
-    public static bool LongBoyStart_Patch(LongBoiPlayerBody __instance)
+    public static bool LongBoyStart_Prefix(LongBoiPlayerBody __instance)
     {
         //Fixes more runtime issues
         __instance.ShouldLongAround = true;
@@ -129,7 +129,7 @@ public static class LongBoiPatches
 
     [HarmonyPatch(nameof(LongBoiPlayerBody.SetHeighFromDistanceHnS))]
     [HarmonyPrefix]
-    public static bool LongBoyNeckSize_Patch(LongBoiPlayerBody __instance, ref float distance)
+    public static bool LongBoyNeckSize_Prefix(LongBoiPlayerBody __instance, ref float distance)
     {
         //Remove the limit of neck size to prevent issues in TOHE HnS
 
@@ -140,7 +140,7 @@ public static class LongBoiPatches
 
     [HarmonyPatch(typeof(HatManager), nameof(HatManager.CheckLongModeValidCosmetic))]
     [HarmonyPrefix]
-    public static bool CheckLongMode_Patch(out bool __result, ref string cosmeticID)
+    public static bool CheckLongMode_Prefix(out bool __result, ref string cosmeticID)
     {
         if (Main.HorseMode.Value)
         {

--- a/Patches/MainMenuManagerPatch.cs
+++ b/Patches/MainMenuManagerPatch.cs
@@ -101,7 +101,7 @@ public static class MainMenuManagerPatch
     //private static PassiveButton patreonButton;
 
     [HarmonyPatch(nameof(MainMenuManager.Start)), HarmonyPostfix, HarmonyPriority(Priority.Normal)]
-    public static void StartPostfix(MainMenuManager __instance)
+    public static void Start_Postfix(MainMenuManager __instance)
     {
         if (template == null) template = __instance.quitButton;
 
@@ -355,12 +355,12 @@ public static class MainMenuManagerPatch
     [HarmonyPatch(nameof(MainMenuManager.OpenAccountMenu))]
     [HarmonyPatch(nameof(MainMenuManager.OpenCredits))]
     [HarmonyPostfix]
-    public static void OpenMenuPostfix()
+    public static void OpenMenu_Postfix()
     {
         if (MainMenuManagerStartPatch.ToheLogo != null) MainMenuManagerStartPatch.ToheLogo.gameObject.SetActive(false);
     }
     [HarmonyPatch(nameof(MainMenuManager.ResetScreen)), HarmonyPostfix]
-    public static void ResetScreenPostfix()
+    public static void ResetScreen_Postfix()
     {
         if (MainMenuManagerStartPatch.ToheLogo != null) MainMenuManagerStartPatch.ToheLogo.gameObject.SetActive(true);
     }

--- a/Patches/MovingPlatformBehaviourPatch.cs
+++ b/Patches/MovingPlatformBehaviourPatch.cs
@@ -8,7 +8,7 @@ public static class MovingPlatformBehaviourPatch
     private static bool isDisabled = false;
 
     [HarmonyPatch(nameof(MovingPlatformBehaviour.Start)), HarmonyPrefix]
-    public static void StartPrefix(MovingPlatformBehaviour __instance)
+    public static void Start_Prefix(MovingPlatformBehaviour __instance)
     {
         isDisabled = Options.DisableAirshipMovingPlatform.GetBool();
 
@@ -19,7 +19,7 @@ public static class MovingPlatformBehaviourPatch
         }
     }
     [HarmonyPatch(nameof(MovingPlatformBehaviour.IsDirty), MethodType.Getter), HarmonyPrefix]
-    public static bool GetIsDirtyPrefix(ref bool __result)
+    public static bool GetIsDirty_Prefix(ref bool __result)
     {
         if (isDisabled)
         {
@@ -29,7 +29,7 @@ public static class MovingPlatformBehaviourPatch
         return true;
     }
     [HarmonyPatch(nameof(MovingPlatformBehaviour.Use), typeof(PlayerControl)), HarmonyPrefix]
-    public static bool UsePrefix() => !isDisabled;
+    public static bool Use_Prefix() => !isDisabled;
     [HarmonyPatch(nameof(MovingPlatformBehaviour.SetSide)), HarmonyPrefix]
-    public static bool SetSidePrefix() => !isDisabled;
+    public static bool SetSide_Prefix() => !isDisabled;
 }

--- a/Patches/ShowHostMeetingPatch.cs
+++ b/Patches/ShowHostMeetingPatch.cs
@@ -15,7 +15,7 @@ public class ShowHostMeetingPatch
 
     [HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.OnDestroy))]
     [HarmonyPostfix]
-    public static void OnDestroyPostfix()
+    public static void OnDestroy_Postfix()
     {
         try
         {
@@ -37,7 +37,7 @@ public class ShowHostMeetingPatch
 
     [HarmonyPatch(typeof(IntroCutscene), nameof(IntroCutscene.ShowRole))]
     [HarmonyPostfix]
-    public static void ShowRolePostfix()
+    public static void ShowRole_Postfix()
     {
         HostControl = AmongUsClient.Instance.GetHost().Character;
         hostName = AmongUsClient.Instance.GetHost().Character.CurrentOutfit.PlayerName;
@@ -46,7 +46,7 @@ public class ShowHostMeetingPatch
 
     [HarmonyPatch(typeof(MeetingHud), nameof(MeetingHud.Update))]
     [HarmonyPostfix]
-    public static void UpdatePostfix(MeetingHud __instance)
+    public static void Update_Postfix(MeetingHud __instance)
     {
         // Not display in local game, because it will be impossible to complete the meeting
         if (!GameStates.IsOnlineGame) return;
@@ -58,7 +58,7 @@ public class ShowHostMeetingPatch
     [HarmonyPatch(typeof(MeetingHud), nameof(MeetingHud.Start))]
     [HarmonyPostfix]
 
-    public static void Setup(MeetingHud __instance)
+    public static void Setup_Postfix(MeetingHud __instance)
     {
         if (!GameStates.IsOnlineGame) return;
 

--- a/Roles/AddOns/Common/Oiiai.cs
+++ b/Roles/AddOns/Common/Oiiai.cs
@@ -17,7 +17,7 @@ public static class Oiiai
     private static OptionItem CanPassOn;
     private static OptionItem ChangeNeutralRole;
 
-    private enum ChangeRolesSelect
+    private enum ChangeRolesSelectList
     {
         Role_NoChange,
         Role_Amnesiac,
@@ -37,7 +37,7 @@ public static class Oiiai
         CanBeOnCrew = BooleanOptionItem.Create(Id + 12, "CrewCanBeOiiai", true, TabGroup.Addons, false).SetParent(Options.CustomRoleSpawnChances[CustomRoles.Oiiai]);
         CanBeOnNeutral = BooleanOptionItem.Create(Id + 13, "NeutralCanBeOiiai", true, TabGroup.Addons, false).SetParent(Options.CustomRoleSpawnChances[CustomRoles.Oiiai]);
         CanPassOn = BooleanOptionItem.Create(Id + 14, "OiiaiCanPassOn", true, TabGroup.Addons, false).SetParent(Options.CustomRoleSpawnChances[CustomRoles.Oiiai]);
-        ChangeNeutralRole = StringOptionItem.Create(Id + 15, "NeutralChangeRolesForOiiai", EnumHelper.GetAllNames<ChangeRolesSelect>(), 1, TabGroup.Addons, false).SetParent(Options.CustomRoleSpawnChances[CustomRoles.Oiiai]);
+        ChangeNeutralRole = StringOptionItem.Create(Id + 15, "NeutralChangeRolesForOiiai", EnumHelper.GetAllNames<ChangeRolesSelectList>(), 1, TabGroup.Addons, false).SetParent(Options.CustomRoleSpawnChances[CustomRoles.Oiiai]);
     }
     public static void Init()
     {

--- a/Roles/Crewmate/Medic.cs
+++ b/Roles/Crewmate/Medic.cs
@@ -29,7 +29,7 @@ internal class Medic : RoleBase
 
     private static byte TempMarkProtected;
 
-    private enum SelectOptions
+    private enum SelectOptionsList
     {
         Medic_SeeMedicAndTarget,
         Medic_SeeMedic,
@@ -37,7 +37,7 @@ internal class Medic : RoleBase
         Medic_SeeNoOne
     }
 
-    private enum ShieldDeactivationIsVisible
+    private enum ShieldDeactivationIsVisibleList
     {
         MedicShieldDeactivationIsVisible_Immediately,
         MedicShieldDeactivationIsVisible_AfterMeeting,
@@ -47,13 +47,13 @@ internal class Medic : RoleBase
     public override void SetupCustomOption()
     {
         Options.SetupRoleOptions(Id, TabGroup.CrewmateRoles, CustomRoles.Medic);
-        WhoCanSeeProtectOpt = StringOptionItem.Create(Id + 10, "MedicWhoCanSeeProtect", EnumHelper.GetAllNames<SelectOptions>(), 0, TabGroup.CrewmateRoles, false)
+        WhoCanSeeProtectOpt = StringOptionItem.Create(Id + 10, "MedicWhoCanSeeProtect", EnumHelper.GetAllNames<SelectOptionsList>(), 0, TabGroup.CrewmateRoles, false)
             .SetParent(Options.CustomRoleSpawnChances[CustomRoles.Medic]);
-        KnowShieldBrokenOpt = StringOptionItem.Create(Id + 16, "MedicKnowShieldBroken", EnumHelper.GetAllNames<SelectOptions>(), 1, TabGroup.CrewmateRoles, false)
+        KnowShieldBrokenOpt = StringOptionItem.Create(Id + 16, "MedicKnowShieldBroken", EnumHelper.GetAllNames<SelectOptionsList>(), 1, TabGroup.CrewmateRoles, false)
            .SetParent(Options.CustomRoleSpawnChances[CustomRoles.Medic]);
         ShieldDeactivatesWhenMedicDies = BooleanOptionItem.Create(Id + 24, "MedicShieldDeactivatesWhenMedicDies", true, TabGroup.CrewmateRoles, false)
             .SetParent(Options.CustomRoleSpawnChances[CustomRoles.Medic]);
-        ShieldDeactivationIsVisibleOpt = StringOptionItem.Create(Id + 25, "MedicShielDeactivationIsVisible", EnumHelper.GetAllNames<ShieldDeactivationIsVisible>(), 0, TabGroup.CrewmateRoles, false)
+        ShieldDeactivationIsVisibleOpt = StringOptionItem.Create(Id + 25, "MedicShielDeactivationIsVisible", EnumHelper.GetAllNames<ShieldDeactivationIsVisibleList>(), 0, TabGroup.CrewmateRoles, false)
             .SetParent(ShieldDeactivatesWhenMedicDies);
         ResetCooldown = FloatOptionItem.Create(Id + 30, "MedicResetCooldown", new(0f, 120f, 1f), 10f, TabGroup.CrewmateRoles, false)
             .SetParent(Options.CustomRoleSpawnChances[CustomRoles.Medic])

--- a/Roles/Crewmate/Sheriff.cs
+++ b/Roles/Crewmate/Sheriff.cs
@@ -38,7 +38,7 @@ internal class Sheriff : RoleBase
 
     private static readonly Dictionary<CustomRoles, OptionItem> KillTargetOptions = [];
 
-    private enum KillOption
+    private enum KillOptionList
     {
         SheriffCanKillAll,
         SheriffCanKillSeparately
@@ -62,7 +62,7 @@ internal class Sheriff : RoleBase
         CanKillInfected = BooleanOptionItem.Create(Id + 26, "SheriffCanKillInfected", true, TabGroup.CrewmateRoles, false).SetParent(Options.CustomRoleSpawnChances[CustomRoles.Sheriff]);
         CanKillContagious = BooleanOptionItem.Create(Id + 27, "SheriffCanKillContagious", true, TabGroup.CrewmateRoles, false).SetParent(Options.CustomRoleSpawnChances[CustomRoles.Sheriff]);
         CanKillNeutrals = BooleanOptionItem.Create(Id + 16, "SheriffCanKillNeutrals", true, TabGroup.CrewmateRoles, false).SetParent(Options.CustomRoleSpawnChances[CustomRoles.Sheriff]);
-        CanKillNeutralsMode = StringOptionItem.Create(Id + 14, "SheriffCanKillNeutralsMode", EnumHelper.GetAllNames<KillOption>(), 0, TabGroup.CrewmateRoles, false).SetParent(CanKillNeutrals);
+        CanKillNeutralsMode = StringOptionItem.Create(Id + 14, "SheriffCanKillNeutralsMode", EnumHelper.GetAllNames<KillOptionList>(), 0, TabGroup.CrewmateRoles, false).SetParent(CanKillNeutrals);
         SetUpNeutralOptions(Id + 30);
         SidekickSheriffCanGoBerserk = BooleanOptionItem.Create(Id + 28, "SidekickSheriffCanGoBerserk", true, TabGroup.CrewmateRoles, false).SetParent(Options.CustomRoleSpawnChances[CustomRoles.Sheriff]);
         SetNonCrewCanKill = BooleanOptionItem.Create(Id + 18, "SheriffSetMadCanKill", false, TabGroup.CrewmateRoles, false).SetParent(Options.CustomRoleSpawnChances[CustomRoles.Sheriff]);

--- a/Roles/Impostor/Godfather.cs
+++ b/Roles/Impostor/Godfather.cs
@@ -17,7 +17,7 @@ internal class Godfather : RoleBase
 
     private static readonly HashSet<byte> GodfatherTarget = [];
 
-    private enum GodfatherChangeMode
+    private enum GodfatherChangeModeList
     {
         GodfatherCount_Refugee,
         GodfatherCount_Madmate
@@ -26,7 +26,7 @@ internal class Godfather : RoleBase
     public override void SetupCustomOption()
     {
         Options.SetupRoleOptions(Id, TabGroup.ImpostorRoles, CustomRoles.Godfather);
-        GodfatherChangeOpt = StringOptionItem.Create(Id + 2, "GodfatherTargetCountMode", EnumHelper.GetAllNames<GodfatherChangeMode>(), 0, TabGroup.ImpostorRoles, false)
+        GodfatherChangeOpt = StringOptionItem.Create(Id + 2, "GodfatherTargetCountMode", EnumHelper.GetAllNames<GodfatherChangeModeList>(), 0, TabGroup.ImpostorRoles, false)
             .SetParent(Options.CustomRoleSpawnChances[CustomRoles.Godfather]);
     }
 

--- a/Roles/Impostor/Vampire.cs
+++ b/Roles/Impostor/Vampire.cs
@@ -26,12 +26,12 @@ internal class Vampire : RoleBase
     private static OptionItem CanVent;
     private static OptionItem ActionModeOpt;
 
-    private enum ActionMode
+    private enum ActionModeList
     {
         Vampire_OnlyBites,
         TriggerDouble
     }
-    private static ActionMode NowActionMode;
+    private static ActionModeList NowActionMode;
 
     private static float KillDelay = new();
     private static readonly Dictionary<byte, BittenInfo> BittenPlayers = [];
@@ -42,7 +42,7 @@ internal class Vampire : RoleBase
         OptionKillDelay = FloatOptionItem.Create(Id + 10, "VampireKillDelay", new(1f, 60f, 1f), 10f, TabGroup.ImpostorRoles, false).SetParent(Options.CustomRoleSpawnChances[CustomRoles.Vampire])
             .SetValueFormat(OptionFormat.Seconds);
         CanVent = BooleanOptionItem.Create(Id + 11, "CanVent", true, TabGroup.ImpostorRoles, false).SetParent(Options.CustomRoleSpawnChances[CustomRoles.Vampire]);
-        ActionModeOpt = StringOptionItem.Create(Id + 12, "VampireActionMode", EnumHelper.GetAllNames<ActionMode>(), 2, TabGroup.ImpostorRoles, false)
+        ActionModeOpt = StringOptionItem.Create(Id + 12, "VampireActionMode", EnumHelper.GetAllNames<ActionModeList>(), 2, TabGroup.ImpostorRoles, false)
             .SetParent(Options.CustomRoleSpawnChances[CustomRoles.Vampire]);
     }
     public override void Init()
@@ -51,13 +51,13 @@ internal class Vampire : RoleBase
         BittenPlayers.Clear();
 
         KillDelay = OptionKillDelay.GetFloat();
-        NowActionMode = (ActionMode)ActionModeOpt.GetValue();
+        NowActionMode = (ActionModeList)ActionModeOpt.GetValue();
     }
     public override void Add(byte playerId)
     {
         playerIdList.Add(playerId);
 
-        if (NowActionMode == ActionMode.TriggerDouble)
+        if (NowActionMode == ActionModeList.TriggerDouble)
         {
             Utils.GetPlayerById(playerId)?.AddDoubleTrigger();
         }
@@ -70,7 +70,7 @@ internal class Vampire : RoleBase
     {
         if (target.Is(CustomRoles.Bait)) return true;
 
-        if (NowActionMode == ActionMode.Vampire_OnlyBites)
+        if (NowActionMode == ActionModeList.Vampire_OnlyBites)
         {
             killer.SetKillCooldown();
             killer.RPCPlayCustomSound("Bite");
@@ -80,7 +80,7 @@ internal class Vampire : RoleBase
                 BittenPlayers.Add(target.PlayerId, new(killer.PlayerId, 0f));
             }
         }
-        else if (NowActionMode == ActionMode.TriggerDouble)
+        else if (NowActionMode == ActionModeList.TriggerDouble)
         {
             return killer.CheckDoubleTrigger(target, () =>
             {

--- a/Roles/Impostor/Witch.cs
+++ b/Roles/Impostor/Witch.cs
@@ -22,18 +22,18 @@ internal class Witch : RoleBase
     private static readonly Dictionary<byte, bool> SpellMode = [];
     private static readonly Dictionary<byte, HashSet<byte>> SpelledPlayer = [];
 
-    private enum SwitchTrigger
+    private enum SwitchTriggerList
     {
         TriggerKill,
         TriggerVent,
         TriggerDouble,
     };
-    private static SwitchTrigger NowSwitchTrigger;
+    private static SwitchTriggerList NowSwitchTrigger;
 
     public override void SetupCustomOption()
     {
         SetupRoleOptions(Id, TabGroup.ImpostorRoles, CustomRoles.Witch);
-        ModeSwitchActionOpt = StringOptionItem.Create(Id + 10, "WitchModeSwitchAction", EnumHelper.GetAllNames<SwitchTrigger>(), 2, TabGroup.ImpostorRoles, false)
+        ModeSwitchActionOpt = StringOptionItem.Create(Id + 10, "WitchModeSwitchAction", EnumHelper.GetAllNames<SwitchTriggerList>(), 2, TabGroup.ImpostorRoles, false)
             .SetParent(CustomRoleSpawnChances[CustomRoles.Witch]);
     }
     public override void Init()
@@ -47,7 +47,7 @@ internal class Witch : RoleBase
         playerIdList.Add(playerId);
         SpellMode.Add(playerId, false);
         SpelledPlayer.Add(playerId, []);
-        NowSwitchTrigger = (SwitchTrigger)ModeSwitchActionOpt.GetValue();
+        NowSwitchTrigger = (SwitchTriggerList)ModeSwitchActionOpt.GetValue();
 
         var pc = Utils.GetPlayerById(playerId);
         pc.AddDoubleTrigger();
@@ -99,10 +99,10 @@ internal class Witch : RoleBase
         bool needSwitch = false;
         switch (NowSwitchTrigger)
         {
-            case SwitchTrigger.TriggerKill:
+            case SwitchTriggerList.TriggerKill:
                 needSwitch = kill;
                 break;
-            case SwitchTrigger.TriggerVent:
+            case SwitchTriggerList.TriggerVent:
                 needSwitch = !kill;
                 break;
         }
@@ -140,7 +140,7 @@ internal class Witch : RoleBase
 
     public override bool OnCheckMurderAsKiller(PlayerControl killer, PlayerControl target)
     {
-        if (NowSwitchTrigger == SwitchTrigger.TriggerDouble)
+        if (NowSwitchTrigger == SwitchTriggerList.TriggerDouble)
         {
             return killer.CheckDoubleTrigger(target, () => { SetSpelled(killer, target); });
         }
@@ -194,7 +194,7 @@ internal class Witch : RoleBase
     }
     public override void OnEnterVent(PlayerControl pc, Vent vent)
     {
-        if (NowSwitchTrigger is SwitchTrigger.TriggerVent)
+        if (NowSwitchTrigger is SwitchTriggerList.TriggerVent)
         {
             SwitchSpellMode(pc.PlayerId, false);
         }
@@ -223,7 +223,7 @@ internal class Witch : RoleBase
         {
             str.Append($"{GetString("Mode")}: ");
         }
-        if (NowSwitchTrigger == SwitchTrigger.TriggerDouble)
+        if (NowSwitchTrigger == SwitchTriggerList.TriggerDouble)
         {
             str.Append(GetString("WitchModeDouble"));
         }
@@ -235,7 +235,7 @@ internal class Witch : RoleBase
     }
     public override void SetAbilityButtonText(HudManager hud, byte playerId)
     {
-        if (IsSpellMode(playerId) && NowSwitchTrigger != SwitchTrigger.TriggerDouble)
+        if (IsSpellMode(playerId) && NowSwitchTrigger != SwitchTriggerList.TriggerDouble)
         {
             hud.KillButton.OverrideText(GetString("WitchSpellButtonText"));
         }

--- a/Roles/Neutral/Amnesiac.cs
+++ b/Roles/Neutral/Amnesiac.cs
@@ -20,7 +20,7 @@ internal class Amnesiac : RoleBase
     private static OptionItem IncompatibleNeutralMode;
     private static OptionItem ShowArrows;
 
-    private enum AmnesiacIncompatibleNeutralModeSelect
+    private enum AmnesiacIncompatibleNeutralModeSelectList
     {
         Role_Amnesiac,
         Role_Pursuer,
@@ -32,7 +32,7 @@ internal class Amnesiac : RoleBase
     public override void SetupCustomOption()
     {
         SetupRoleOptions(Id, TabGroup.NeutralRoles, CustomRoles.Amnesiac);
-        IncompatibleNeutralMode = StringOptionItem.Create(Id + 10, "IncompatibleNeutralMode", EnumHelper.GetAllNames<AmnesiacIncompatibleNeutralModeSelect>(), 0, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Amnesiac]);
+        IncompatibleNeutralMode = StringOptionItem.Create(Id + 10, "IncompatibleNeutralMode", EnumHelper.GetAllNames<AmnesiacIncompatibleNeutralModeSelectList>(), 0, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Amnesiac]);
         ShowArrows = BooleanOptionItem.Create(Id + 11, "ShowArrows", false, TabGroup.NeutralRoles, false).SetParent(Options.CustomRoleSpawnChances[CustomRoles.Amnesiac]);
     }
     public override void Init()

--- a/Roles/Neutral/Bandit.cs
+++ b/Roles/Neutral/Bandit.cs
@@ -27,7 +27,7 @@ internal class Bandit : RoleBase
     private float killCooldown;
     private Dictionary<byte, CustomRoles> Targets = [];
 
-    private enum BanditStealModeOpt
+    private enum BanditStealModeOptList
     {
         BanditStealMode_OnMeeting,
         BanditStealMode_Instantly
@@ -41,7 +41,7 @@ internal class Bandit : RoleBase
             .SetValueFormat(OptionFormat.Seconds);
         StealCooldown = FloatOptionItem.Create(Id + 17, "BanditStealCooldown", new(0f, 180f, 2.5f), 10f, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Bandit])
             .SetValueFormat(OptionFormat.Seconds);
-        StealMode = StringOptionItem.Create(Id + 12, "BanditStealMode", EnumHelper.GetAllNames<BanditStealModeOpt>(), 0, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Bandit]);
+        StealMode = StringOptionItem.Create(Id + 12, "BanditStealMode", EnumHelper.GetAllNames<BanditStealModeOptList>(), 0, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Bandit]);
         CanStealBetrayalAddon = BooleanOptionItem.Create(Id + 13, "BanditCanStealBetrayalAddon", true, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Bandit]);
         CanStealImpOnlyAddon = BooleanOptionItem.Create(Id + 14, "BanditCanStealImpOnlyAddon", true, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Bandit]);
         CanUsesSabotage = BooleanOptionItem.Create(Id + 15, "CanUseSabotage", true, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Bandit]);

--- a/Roles/Neutral/Cultist.cs
+++ b/Roles/Neutral/Cultist.cs
@@ -24,7 +24,7 @@ internal class Cultist : RoleBase
     private static OptionItem CanCharmNeutral;
     public static OptionItem CharmedCountMode;
 
-    private enum CharmedCountModeSelect
+    private enum CharmedCountModeSelectList
     {
         Cultist_CharmedCountMode_None,
         Cultist_CharmedCountMode_Cultist,
@@ -42,7 +42,7 @@ internal class Cultist : RoleBase
             .SetValueFormat(OptionFormat.Times);
         KnowTargetRole = BooleanOptionItem.Create(Id + 13, "CultistKnowTargetRole", true, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Cultist]);
         TargetKnowOtherTarget = BooleanOptionItem.Create(Id + 14, "CultistTargetKnowOtherTarget", true, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Cultist]);
-        CharmedCountMode = StringOptionItem.Create(Id + 17, "Cultist_CharmedCountMode", EnumHelper.GetAllNames<CharmedCountModeSelect>(), 1, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Cultist]);
+        CharmedCountMode = StringOptionItem.Create(Id + 17, "Cultist_CharmedCountMode", EnumHelper.GetAllNames<CharmedCountModeSelectList>(), 1, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Cultist]);
         CanCharmNeutral = BooleanOptionItem.Create(Id + 18, "CultistCanCharmNeutral", false, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Cultist]);
     }
     public override void Add(byte playerId)

--- a/Roles/Neutral/Executioner.cs
+++ b/Roles/Neutral/Executioner.cs
@@ -26,7 +26,7 @@ internal class Executioner : RoleBase
 
     public static readonly Dictionary<byte, byte> Target = [];
     
-    private enum ChangeRolesSelect
+    private enum ChangeRolesSelectList
     {
         Role_Crewmate,
         Role_Celebrity,
@@ -58,7 +58,7 @@ internal class Executioner : RoleBase
         CanTargetNeutralEvil = BooleanOptionItem.Create(Id + 15, "ExecutionerCanTargetNeutralEvil", false, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Executioner]);
         CanTargetNeutralChaos = BooleanOptionItem.Create(Id + 16, "ExecutionerCanTargetNeutralChaos", false, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Executioner]);
         KnowTargetRole = BooleanOptionItem.Create(Id + 13, "KnowTargetRole", false, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Executioner]);
-        ChangeRolesAfterTargetKilled = StringOptionItem.Create(Id + 11, "ExecutionerChangeRolesAfterTargetKilled", EnumHelper.GetAllNames<ChangeRolesSelect>(), 1, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Executioner]);
+        ChangeRolesAfterTargetKilled = StringOptionItem.Create(Id + 11, "ExecutionerChangeRolesAfterTargetKilled", EnumHelper.GetAllNames<ChangeRolesSelectList>(), 1, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Executioner]);
     }
     public override void Init()
     {

--- a/Roles/Neutral/HexMaster.cs
+++ b/Roles/Neutral/HexMaster.cs
@@ -30,18 +30,18 @@ internal class HexMaster : RoleBase
     private static readonly Color RoleColorHex = Utils.GetRoleColor(CustomRoles.HexMaster);
     private static readonly Color RoleColorSpell = Utils.GetRoleColor(CustomRoles.Impostor);
 
-    private enum SwitchTrigger
+    private enum SwitchTriggerList
     {
         TriggerKill,
         TriggerVent,
         TriggerDouble,
     };
-    private static SwitchTrigger NowSwitchTrigger;
+    private static SwitchTriggerList NowSwitchTrigger;
 
     public override void SetupCustomOption()
     {
         SetupSingleRoleOptions(Id, TabGroup.NeutralRoles, CustomRoles.HexMaster, 1, zeroOne: false);        
-        ModeSwitchAction = StringOptionItem.Create(Id + 10, "WitchModeSwitchAction", EnumHelper.GetAllNames<SwitchTrigger>(), 2, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.HexMaster]);
+        ModeSwitchAction = StringOptionItem.Create(Id + 10, "WitchModeSwitchAction", EnumHelper.GetAllNames<SwitchTriggerList>(), 2, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.HexMaster]);
         HexesLookLikeSpells = BooleanOptionItem.Create(Id + 11, "HexesLookLikeSpells",  false, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.HexMaster]);
         HasImpostorVision = BooleanOptionItem.Create(Id + 12, "ImpostorVision",  true, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.HexMaster]);
     }
@@ -56,7 +56,7 @@ internal class HexMaster : RoleBase
         playerIdList.Add(playerId);
         HexMode.Add(playerId, false);
         HexedPlayer.Add(playerId, []);
-        NowSwitchTrigger = (SwitchTrigger)ModeSwitchAction.GetValue();
+        NowSwitchTrigger = (SwitchTriggerList)ModeSwitchAction.GetValue();
 
         var pc = Utils.GetPlayerById(playerId);
         pc.AddDoubleTrigger();
@@ -120,10 +120,10 @@ internal class HexMaster : RoleBase
         bool needSwitch = false;
         switch (NowSwitchTrigger)
         {
-            case SwitchTrigger.TriggerKill:
+            case SwitchTriggerList.TriggerKill:
                 needSwitch = kill;
                 break;
-            case SwitchTrigger.TriggerVent:
+            case SwitchTriggerList.TriggerVent:
                 needSwitch = !kill;
                 break;
         }
@@ -165,7 +165,7 @@ internal class HexMaster : RoleBase
         if (Medic.ProtectList.Contains(target.PlayerId)) return false;
         if (target.Is(CustomRoles.Pestilence)) return false;
 
-        if (NowSwitchTrigger == SwitchTrigger.TriggerDouble)
+        if (NowSwitchTrigger == SwitchTriggerList.TriggerDouble)
         {
             return killer.CheckDoubleTrigger(target, () => { SetHexed(killer, target); });
         }
@@ -227,7 +227,7 @@ internal class HexMaster : RoleBase
     }
     public override void OnEnterVent(PlayerControl pc, Vent vent)
     {
-        if (NowSwitchTrigger is SwitchTrigger.TriggerVent)
+        if (NowSwitchTrigger is SwitchTriggerList.TriggerVent)
         {
             SwitchHexMode(pc.PlayerId, false);
         }
@@ -258,7 +258,7 @@ internal class HexMaster : RoleBase
         {
             
             str.Append($"{GetString("Mode")}:");
-            if (NowSwitchTrigger == SwitchTrigger.TriggerDouble)
+            if (NowSwitchTrigger == SwitchTriggerList.TriggerDouble)
             {
                 str.Append(GetString("HexMasterModeDouble"));
             }
@@ -278,7 +278,7 @@ internal class HexMaster : RoleBase
 
         var str = new StringBuilder();
         str.Append(GetString("WitchCurrentMode"));
-        if (NowSwitchTrigger == SwitchTrigger.TriggerDouble)
+        if (NowSwitchTrigger == SwitchTriggerList.TriggerDouble)
         {
             str.Append(GetString("HexMasterModeDouble"));
         }
@@ -292,7 +292,7 @@ internal class HexMaster : RoleBase
     
     public override void SetAbilityButtonText(HudManager hud, byte playerid)
     {
-        if (IsHexMode(playerid) && NowSwitchTrigger != SwitchTrigger.TriggerDouble)
+        if (IsHexMode(playerid) && NowSwitchTrigger != SwitchTriggerList.TriggerDouble)
         {
             hud.KillButton.OverrideText($"{GetString("HexButtonText")}");
         }

--- a/Roles/Neutral/Imitator.cs
+++ b/Roles/Neutral/Imitator.cs
@@ -16,7 +16,7 @@ internal class Imitator : RoleBase
     private static OptionItem RememberCooldown;
     private static OptionItem IncompatibleNeutralMode;
 
-    private enum ImitatorIncompatibleNeutralModeSelect
+    private enum ImitatorIncompatibleNeutralModeSelectList
     {
         Role_Imitator,
         Role_Pursuer,
@@ -30,7 +30,7 @@ internal class Imitator : RoleBase
         SetupRoleOptions(Id, TabGroup.NeutralRoles, CustomRoles.Imitator);
         RememberCooldown = FloatOptionItem.Create(Id + 10, "RememberCooldown", new(0f, 180f, 2.5f), 25f, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Imitator])
                 .SetValueFormat(OptionFormat.Seconds);
-        IncompatibleNeutralMode = StringOptionItem.Create(Id + 12, "IncompatibleNeutralMode", EnumHelper.GetAllNames<ImitatorIncompatibleNeutralModeSelect>(), 0, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Imitator]);
+        IncompatibleNeutralMode = StringOptionItem.Create(Id + 12, "IncompatibleNeutralMode", EnumHelper.GetAllNames<ImitatorIncompatibleNeutralModeSelectList>(), 0, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Imitator]);
     }
     public override void Add(byte playerId)
     {

--- a/Roles/Neutral/Jackal.cs
+++ b/Roles/Neutral/Jackal.cs
@@ -35,13 +35,13 @@ internal class Jackal : RoleBase
     public static OptionItem CanUseSabotageSK;
     private static OptionItem SidekickCanKillJackal;
     private static OptionItem SidekickCanKillSidekick;
-    private enum SidekickAssignModeSelect
+    private enum SidekickAssignModeSelectList
     {
         Jackal_SidekickAssignMode_SidekickAndRecruit,
         Jackal_SidekickAssignMode_Sidekick,
         Jackal_SidekickAssignMode_Recruit,
     }
-    private enum SidekickCountModeSelect
+    private enum SidekickCountModeSelectList
     {
         Jackal_SidekickCountMode_Jackal,
         Jackal_SidekickCountMode_None,
@@ -63,7 +63,7 @@ internal class Jackal : RoleBase
             .SetValueFormat(OptionFormat.Seconds);
         JackalCanKillSidekick = BooleanOptionItem.Create(Id + 15, "JackalCanKillSidekick", false, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Jackal]);
         CanRecruitSidekick = BooleanOptionItem.Create(Id + 30, "JackalCanRecruitSidekick", true, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Jackal]);
-        SidekickAssignMode = StringOptionItem.Create(Id + 34, "Jackal_SidekickAssignMode", EnumHelper.GetAllNames<SidekickAssignModeSelect>(), 0, TabGroup.NeutralRoles, false).SetParent(CanRecruitSidekick)
+        SidekickAssignMode = StringOptionItem.Create(Id + 34, "Jackal_SidekickAssignMode", EnumHelper.GetAllNames<SidekickAssignModeSelectList>(), 0, TabGroup.NeutralRoles, false).SetParent(CanRecruitSidekick)
                 .SetHidden(false);
         SidekickRecruitLimitOpt = IntegerOptionItem.Create(Id + 33, "JackalSidekickRecruitLimit", new(0, 15, 1), 2, TabGroup.NeutralRoles, false).SetParent(CanRecruitSidekick)
                 .SetValueFormat(OptionFormat.Times);
@@ -73,7 +73,7 @@ internal class Jackal : RoleBase
         CanUseSabotageSK = BooleanOptionItem.Create(Id + 22, "CanUseSabotage", true, TabGroup.NeutralRoles, false).SetParent(CanRecruitSidekick);
         SidekickCanKillJackal = BooleanOptionItem.Create(Id + 23, "Jackal_SidekickCanKillJackal", false, TabGroup.NeutralRoles, false).SetParent(CanRecruitSidekick);
         SidekickCanKillSidekick = BooleanOptionItem.Create(Id + 24, "Jackal_SidekickCanKillSidekick", false, TabGroup.NeutralRoles, false).SetParent(CanRecruitSidekick);
-        SidekickCountMode = StringOptionItem.Create(Id + 25, "Jackal_SidekickCountMode", EnumHelper.GetAllNames<SidekickCountModeSelect>(), 0, TabGroup.NeutralRoles, false).SetParent(CanRecruitSidekick)
+        SidekickCountMode = StringOptionItem.Create(Id + 25, "Jackal_SidekickCountMode", EnumHelper.GetAllNames<SidekickCountModeSelectList>(), 0, TabGroup.NeutralRoles, false).SetParent(CanRecruitSidekick)
             .SetHidden(false);
     }
     public override void Init()

--- a/Roles/Neutral/Lawyer.cs
+++ b/Roles/Neutral/Lawyer.cs
@@ -26,7 +26,7 @@ internal class Lawyer : RoleBase
     private static OptionItem TargetKnowsLawyer;
 
     public static readonly Dictionary<byte, byte> Target = [];
-    private enum ChangeRolesSelect
+    private enum ChangeRolesSelectList
     {
         Role_Crewmate,
         Role_Jester,
@@ -59,7 +59,7 @@ internal class Lawyer : RoleBase
         KnowTargetRole = BooleanOptionItem.Create(Id + 14, "KnowTargetRole", false, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Lawyer]);
         TargetKnowsLawyer = BooleanOptionItem.Create(Id + 15, "TargetKnowsLawyer", false, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Lawyer]);
         ShouldChangeRoleAfterTargetDeath = BooleanOptionItem.Create(Id + 17, "LaywerShouldChangeRoleAfterTargetKilled", false, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Lawyer]);
-        ChangeRolesAfterTargetKilled = StringOptionItem.Create(Id + 16, "LawyerChangeRolesAfterTargetKilled", EnumHelper.GetAllNames<ChangeRolesSelect>(), 1, TabGroup.NeutralRoles, false).SetParent(ShouldChangeRoleAfterTargetDeath);
+        ChangeRolesAfterTargetKilled = StringOptionItem.Create(Id + 16, "LawyerChangeRolesAfterTargetKilled", EnumHelper.GetAllNames<ChangeRolesSelectList>(), 1, TabGroup.NeutralRoles, false).SetParent(ShouldChangeRoleAfterTargetDeath);
     }
     public override void Init()
     {

--- a/Roles/Neutral/Virus.cs
+++ b/Roles/Neutral/Virus.cs
@@ -31,7 +31,7 @@ internal class Virus : RoleBase
     private static readonly HashSet<byte> InfectedPlayer = [];
     private static readonly Dictionary<byte, string> VirusNotify = [];
 
-    private enum ContagiousCountModeSelect
+    private enum ContagiousCountModeSelectList
     {
         Virus_ContagiousCountMode_None,
         Virus_ContagiousCountMode_Virus,
@@ -50,7 +50,7 @@ internal class Virus : RoleBase
         KnowTargetRole = BooleanOptionItem.Create(Id + 13, "VirusKnowTargetRole", true, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Virus]);
         TargetKnowOtherTarget = BooleanOptionItem.Create(Id + 14, "VirusTargetKnowOtherTarget", true, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Virus]);
         KillInfectedPlayerAfterMeeting = BooleanOptionItem.Create(Id + 15, "VirusKillInfectedPlayerAfterMeeting", false, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Virus]);
-        ContagiousCountMode = StringOptionItem.Create(Id + 18, "Virus_ContagiousCountMode", EnumHelper.GetAllNames<ContagiousCountModeSelect>(), 1, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Virus]);
+        ContagiousCountMode = StringOptionItem.Create(Id + 18, "Virus_ContagiousCountMode", EnumHelper.GetAllNames<ContagiousCountModeSelectList>(), 1, TabGroup.NeutralRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Virus]);
     }
 
     public override void Init()


### PR DESCRIPTION
I'm using Dotfuscator to confuse my own dll build
And i meet many issues

The harmony function can't be renamed or the patch will fail
Enums cant be renamed bcz in mod we use EnumHelper to get the name of the enum and pass to translator