### PR TITLE
Fix killtimer not going when press f1

### DIFF
--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -565,6 +565,7 @@ static class ExtendedPlayerControl
     }
     public static bool CanUseKillButton(this PlayerControl pc)
     {
+        if (GameStates.IsLobby) return false;
         if (!pc.IsAlive() || Pelican.IsEaten(pc.PlayerId)) return false;
         if (DollMaster.IsDoll(pc.PlayerId)) return false;
         if (pc.Is(CustomRoles.Killer) || Mastermind.PlayerIsManipulated(pc)) return true;

--- a/Patches/ControlPatch.cs
+++ b/Patches/ControlPatch.cs
@@ -61,7 +61,7 @@ internal class ControllerManagerUpdatePatch
                     sb.Append(GetString(role.ToString()) + Utils.GetRoleMode(role) + lp.GetRoleInfo(true));
                     if (Options.CustomRoleSpawnChances.TryGetValue(role, out var opt))
                         Utils.ShowChildrenSettings(Options.CustomRoleSpawnChances[role], ref sb, command: true);
-                    HudManager.Instance.ShowPopUp(sb.ToString());
+                    HudManager.Instance.ShowPopUp(sb.ToString() + "<size=0%>tohe</size>");
                 }
                 catch (Exception ex)
                 {
@@ -86,7 +86,7 @@ internal class ControllerManagerUpdatePatch
 
                     addonIndex++;
                     if (addonIndex >= addDes.Count) addonIndex = 0;
-                    HudManager.Instance.ShowPopUp(addDes[addonIndex]);
+                    HudManager.Instance.ShowPopUp(addDes[addonIndex] + "<size=0%>tohe</size>");
                 }
                 catch (Exception ex)
                 {

--- a/Patches/DialogueBoxPatch.cs
+++ b/Patches/DialogueBoxPatch.cs
@@ -1,0 +1,26 @@
+﻿namespace TOHE.Patches;
+[HarmonyPatch(typeof(DialogueBox))]
+internal class DialogueBoxPatch
+{
+    [HarmonyPatch(nameof(DialogueBox.Show)), HarmonyPostfix]
+    public static void Show_Postfix(DialogueBox __instance, [HarmonyArgument(0)]string dialouge)
+    {
+        if (dialouge.Contains("<size=0%>tohe</size>") && GameStates.IsInTask)
+        {
+            PlayerControl.LocalPlayer.ForceKillTimerContinue = true;
+        }
+    }
+
+    [HarmonyPatch(nameof(DialogueBox.Hide)), HarmonyPostfix]
+    public static void Hide_Postfix(DialogueBox __instance)
+    {
+        if (__instance.target.text.Contains("<size=0%>tohe</size>"))
+        {
+            PlayerControl.LocalPlayer.ForceKillTimerContinue = false;
+        }
+    }
+
+    /*
+     * Lets add a <size=0%>tohe</size> at where you will use the dialogue box.
+     */
+}


### PR DESCRIPTION
Not sure whether setting force kill timer will influence other stuffs
Need test probably

Also should be getting rid of mod client having killbutton in lobby by return false in canusekillbutton

The fix is dumb, you gonna need to manually add <size=0%>tohe</size>
It works well though