### PR TITLE
Fix real client name

### DIFF
--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -594,7 +594,7 @@ static class ExtendedPlayerControl
 
             if (client != null)
             {
-                if (OnPlayerJoinedPatch.realClientName.TryGetValue(client.Id, out var realname))
+                if (Main.AllClientRealNames.TryGetValue(client.Id, out var realname))
                 {
                     return realname;
                 }

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -34,7 +34,6 @@ enum CustomRPC : byte // 194/255 USED
     PlayCustomSound,
     SetKillTimer,
     SyncAllPlayerNames,
-    SyncAllClientRealNames,
     SyncNameNotify,
     ShowPopUp,
     KillFlash,
@@ -513,12 +512,10 @@ internal class RPCHandlerPatch
                 break;
             case CustomRPC.SyncAllPlayerNames:
                 Main.AllPlayerNames.Clear();
+                Main.AllClientRealNames.Clear();
                 int num = reader.ReadPackedInt32();
                 for (int i = 0; i < num; i++)
                     Main.AllPlayerNames.TryAdd(reader.ReadByte(), reader.ReadString());
-                break;
-            case CustomRPC.SyncAllClientRealNames:
-                Main.AllClientRealNames.Clear();
                 int num2 = reader.ReadPackedInt32();
                 for (int i = 0; i < num2; i++)
                     Main.AllClientRealNames.TryAdd(reader.ReadInt32(), reader.ReadString());
@@ -728,12 +725,6 @@ internal static class RPC
             writer.Write(name.Key);
             writer.Write(name.Value);
         }
-        AmongUsClient.Instance.FinishRpcImmediately(writer);
-    }
-    public static void SyncAllClientRealNames()
-    {
-        if (!AmongUsClient.Instance.AmHost) return;
-        MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.SyncAllClientRealNames, SendOption.Reliable, -1);
         writer.WritePacked(Main.AllClientRealNames.Count);
         foreach (var name in Main.AllClientRealNames)
         {

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -34,6 +34,7 @@ enum CustomRPC : byte // 194/255 USED
     PlayCustomSound,
     SetKillTimer,
     SyncAllPlayerNames,
+    SyncAllClientRealNames,
     SyncNameNotify,
     ShowPopUp,
     KillFlash,
@@ -516,6 +517,12 @@ internal class RPCHandlerPatch
                 for (int i = 0; i < num; i++)
                     Main.AllPlayerNames.TryAdd(reader.ReadByte(), reader.ReadString());
                 break;
+            case CustomRPC.SyncAllClientRealNames:
+                Main.AllClientRealNames.Clear();
+                int num2 = reader.ReadPackedInt32();
+                for (int i = 0; i < num2; i++)
+                    Main.AllClientRealNames.TryAdd(reader.ReadInt32(), reader.ReadString());
+                break;
             case CustomRPC.SyncFFANameNotify:
                 FFAManager.ReceiveRPCSyncNameNotify(reader);
                 break;
@@ -717,6 +724,18 @@ internal static class RPC
         MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.SyncAllPlayerNames, SendOption.Reliable, -1);
         writer.WritePacked(Main.AllPlayerNames.Count);
         foreach (var name in Main.AllPlayerNames)
+        {
+            writer.Write(name.Key);
+            writer.Write(name.Value);
+        }
+        AmongUsClient.Instance.FinishRpcImmediately(writer);
+    }
+    public static void SyncAllClientRealNames()
+    {
+        if (!AmongUsClient.Instance.AmHost) return;
+        MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.SyncAllClientRealNames, SendOption.Reliable, -1);
+        writer.WritePacked(Main.AllClientRealNames.Count);
+        foreach (var name in Main.AllClientRealNames)
         {
             writer.Write(name.Key);
             writer.Write(name.Value);

--- a/Patches/PlayerControlPatch.cs
+++ b/Patches/PlayerControlPatch.cs
@@ -1560,7 +1560,6 @@ class PlayerControlCheckNamePatch
         if (!Main.AllClientRealNames.ContainsKey(__instance.OwnerId))
         {
             Main.AllClientRealNames.Add(__instance.OwnerId, playerName);
-            RPC.SyncAllClientRealNames();
         }
 
         // Standard nickname
@@ -1578,6 +1577,7 @@ class PlayerControlCheckNamePatch
         Main.AllPlayerNames.TryAdd(__instance.PlayerId, name);
         Logger.Info($"PlayerId: {__instance.PlayerId} - playerName: {playerName} => {name}", "Name player");
 
+        RPC.SyncAllPlayerNames();
         if (__instance != null && !name.Equals(playerName))
         {
             Logger.Warn($"Standard nickname: {playerName} => {name}", "Name Format");

--- a/Patches/PlayerJoinAndLeftPatch.cs
+++ b/Patches/PlayerJoinAndLeftPatch.cs
@@ -34,7 +34,7 @@ class OnGameJoinedPatch
         GameStates.InGame = false;
         ErrorText.Instance.Clear();
         EAC.Init();
-        OnPlayerJoinedPatch.realClientName = [];
+        Main.AllClientRealNames.Clear();
 
         // No game end always enabled because the settings are not done
         Options.NoGameEnd.SetValue(1);
@@ -49,9 +49,9 @@ class OnGameJoinedPatch
                 RehostManager.IsAutoRehostDone = true;
             }
 
-            if (!OnPlayerJoinedPatch.realClientName.ContainsKey(__instance.ClientId))
+            if (!Main.AllClientRealNames.ContainsKey(__instance.ClientId))
             {
-                OnPlayerJoinedPatch.realClientName.Add(__instance.ClientId, DataManager.Player.Customization.Name);
+                Main.AllClientRealNames.Add(__instance.ClientId, DataManager.Player.Customization.Name);
             }
 
             GameStartManagerPatch.GameStartManagerUpdatePatch.exitTimer = -1;
@@ -147,7 +147,7 @@ class OnGameJoinedPatch
                     catch { };
                 }, 1.5f, "Retry Log Local Client");
             }
-        }, 0.6f, "OnGameJoinedPatch");
+        }, 0.7f, "OnGameJoinedPatch");
     }
 }
 [HarmonyPatch(typeof(InnerNetClient), nameof(InnerNetClient.DisconnectInternal))]
@@ -162,7 +162,6 @@ class DisconnectInternalPatch
 [HarmonyPatch(typeof(AmongUsClient), nameof(AmongUsClient.OnPlayerJoined))]
 public static class OnPlayerJoinedPatch
 {
-    public static Dictionary<int, string> realClientName = [];
     public static bool IsDisconnected(this ClientData client)
     {
         var __instance = AmongUsClient.Instance;
@@ -274,10 +273,6 @@ public static class OnPlayerJoinedPatch
         }
         BanManager.CheckBanPlayer(client);
         BanManager.CheckDenyNamePlayer(client);
-        if (!realClientName.ContainsKey(client.Id))
-        {
-            realClientName.Add(client.Id, client.PlayerName);
-        }
 
         if (AmongUsClient.Instance.AmHost)
         {

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -106,6 +106,7 @@ internal class ChangeRoleSettings
 
             // Sync Player Names
             RPC.SyncAllPlayerNames();
+            RPC.SyncAllClientRealNames();
             //Main.AllPlayerNames = [];
 
             GhostRoleAssign.Init();

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -106,7 +106,6 @@ internal class ChangeRoleSettings
 
             // Sync Player Names
             RPC.SyncAllPlayerNames();
-            RPC.SyncAllClientRealNames();
             //Main.AllPlayerNames = [];
 
             GhostRoleAssign.Init();

--- a/main.cs
+++ b/main.cs
@@ -119,6 +119,7 @@ public class Main : BasePlugin
     
     public static Dictionary<byte, PlayerState> PlayerStates = [];
     public static readonly Dictionary<byte, string> AllPlayerNames = [];
+    public static readonly Dictionary<int, string> AllClientRealNames = [];
     public static readonly Dictionary<byte, CustomRoles> AllPlayerCustomRoles = [];
     public static readonly Dictionary<(byte, byte), string> LastNotifyNames = [];
     public static readonly Dictionary<byte, Action> LateOutfits = [];


### PR DESCRIPTION
Mod clients cant get real client name under current protocol, nobody is passing realname to them
So realclientname => AllClientRealNames and are synced by rpc, set by host at check name

Also there is no need of ref playername since all the vanilla set name steps  is done before the postfix
Removed the ref and do another rpc set name there