### PR TITLE
Lightning can't get Tricky

### DIFF
--- a/Modules/CustomRolesHelper.cs
+++ b/Modules/CustomRolesHelper.cs
@@ -801,7 +801,8 @@ public static class CustomRolesHelper
                     return false;
                 break;
             case CustomRoles.Tricky:
-                if (pc.Is(CustomRoles.Mastermind))
+                if (pc.Is(CustomRoles.Mastermind)
+                    || pc.Is(CustomRoles.Lightning))
                     return false;
                 if (!pc.GetCustomRole().IsImpostor())
                     return false;


### PR DESCRIPTION
The Lightning can't kill normally so the Tricky add-on will not work.