### PR TITLE
Disable AssertWithTimeout

### DIFF
--- a/Patches/PlayerControlPatch.cs
+++ b/Patches/PlayerControlPatch.cs
@@ -1892,6 +1892,7 @@ class PlayerControlLocalSetRolePatch
 [HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.AssertWithTimeout))]
 class AssertWithTimeoutPatch
 {
+    // Completely disable the trash put by Innersloth
     public static bool Prefix()
     {
         return false;

--- a/Patches/PlayerControlPatch.cs
+++ b/Patches/PlayerControlPatch.cs
@@ -1888,3 +1888,12 @@ class PlayerControlLocalSetRolePatch
         }
     }
 }
+
+[HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.AssertWithTimeout))]
+class AssertWithTimeoutPatch
+{
+    public static bool Prefix()
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
Currently this function is only used in PlayerControl and do the following things:
1. Put a 30s delay for every player control to wait for its player id change to other values than 255. disconnect everyone if timed out
 -- Custom net object currently uses player id 255, so it will disconnect everyone by keeping a 255 player id
2. Put a 30s delay for every player control to be assigned a networked data. disconnect everyone if timed out
 -- Custom net object wont assign a player data, so it gonna disconnect everyone if it exists for more than 30s
3. Put a 30s delay for every player control to wait for its owner to set the skin in networked data
 -- Since Innersloth broke something relating to +25 client side, lobbies above 7-8 players can easily get green beans and sometimes the client disconnects but playercontrol is kept "invisable" and not completely despawned, thus causing a disconnect for everyone
 --  Completely useless and ridiculos. Disconnects others for a player not sending its own data. The most trash code except the +25 blackout in 6.18 update

Note that the disconnect is completely done client side, host has no control over it. We can only make the modded players not disconnect by disabling this function. Vanilla players still can easily enjoy fresh random disconnects, full and sound.

Repeat the despawn calls so nobody get disconnected by stupid player control
Also fix the bug where message to send to disconnected players is not removed