### PR TITLE
Shaman can't get Fragile

### DIFF
--- a/Modules/CustomRolesHelper.cs
+++ b/Modules/CustomRolesHelper.cs
@@ -607,7 +607,8 @@ public static class CustomRolesHelper
                     || pc.Is(CustomRoles.Pestilence)
                     || pc.Is(CustomRoles.Spy)
                     || pc.Is(CustomRoles.Necromancer)
-                    || pc.Is(CustomRoles.Demon))
+                    || pc.Is(CustomRoles.Demon)
+                    || pc.Is(CustomRoles.Shaman))
                     return false;
                 if ((pc.GetCustomRole().IsCrewmate() && !Fragile.CrewCanBeFragile.GetBool()) || (pc.GetCustomRole().IsNeutral() && !Fragile.NeutralCanBeFragile.GetBool()) || (pc.GetCustomRole().IsImpostor() && !Fragile.ImpCanBeFragile.GetBool()))
                     return false;


### PR DESCRIPTION
When the Shaman uses their kill button on someone to make a voodoo doll, anyone that tries to kill the Shaman will kill the voodoo doll instead. But if the Shaman is Fragile, then it defeats the purpose of the role even after the voodoo doll was selected.