### PR TITLE
Dollmaster Fixes

### DIFF
--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -1824,6 +1824,13 @@ public static class Utils
                         SelfName = GetString("DevouredName");
                 }
 
+                // Dollmaster, Prevent seeing self in mushroom cloud
+                if (CustomRoles.DollMaster.HasEnabled() && seerRole != CustomRoles.DollMaster)
+                {
+                    if (DollMaster.IsDoll(seer.PlayerId))
+                        SelfName = "<size=10000%><color=#000000>■</size></color>";
+                }
+
                 // Camouflage
                 if (!CamouflageIsForMeeting && Camouflage.IsCamouflage)
                     SelfName = $"<size=0%>{SelfName}</size>";

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -1828,12 +1828,15 @@ public static class Utils
                 if (CustomRoles.DollMaster.HasEnabled() && seerRole != CustomRoles.DollMaster)
                 {
                     if (DollMaster.IsDoll(seer.PlayerId))
-                        SelfName = "<size=10000%><color=#000000>■</size></color>";
+                        SelfName = "<size=10000%><color=#000000>■</color></size>";
                 }
 
                 // Camouflage
                 if (!CamouflageIsForMeeting && Camouflage.IsCamouflage)
+                {
                     SelfName = $"<size=0%>{SelfName}</size>";
+                    IsDisplayInfo = false;
+                }
 
                 if (!SelfName.Contains(seer.GetRealName()))
                     IsDisplayInfo = false;

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -1833,10 +1833,7 @@ public static class Utils
 
                 // Camouflage
                 if (!CamouflageIsForMeeting && Camouflage.IsCamouflage)
-                {
                     SelfName = $"<size=0%>{SelfName}</size>";
-                    IsDisplayInfo = false;
-                }
 
                 if (!SelfName.Contains(seer.GetRealName()))
                     IsDisplayInfo = false;

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -1835,7 +1835,7 @@ public static class Utils
                 if (!CamouflageIsForMeeting && Camouflage.IsCamouflage)
                     SelfName = $"<size=0%>{SelfName}</size>";
 
-                if (!SelfName.Contains(seer.GetRealName()))
+                if (!Regex.IsMatch(SelfName, seer.GetRealName()))
                     IsDisplayInfo = false;
 
                 switch (Options.CurrentGameMode)

--- a/Patches/PlayerControlPatch.cs
+++ b/Patches/PlayerControlPatch.cs
@@ -1325,6 +1325,13 @@ class FixedUpdateInNormalGamePatch
                         RealName = GetString("DevouredName");
                 }
 
+                // Dollmaster, Prevent seeing self in mushroom cloud
+                if (CustomRoles.DollMaster.HasEnabled() && seerRole != CustomRoles.DollMaster)
+                {
+                    if (DollMaster.IsDoll(seer.PlayerId))
+                        RealName = "<size=10000%><color=#000000>■</size></color>";
+                }
+
                 // Camouflage
                 if ((Utils.IsActive(SystemTypes.Comms) && Camouflage.IsActive) || Camouflager.AbilityActivated)
                     RealName = $"<size=0%>{RealName}</size> ";

--- a/Patches/PlayerControlPatch.cs
+++ b/Patches/PlayerControlPatch.cs
@@ -1329,7 +1329,7 @@ class FixedUpdateInNormalGamePatch
                 if (CustomRoles.DollMaster.HasEnabled() && seerRole != CustomRoles.DollMaster)
                 {
                     if (DollMaster.IsDoll(seer.PlayerId))
-                        RealName = "<size=10000%><color=#000000>■</size></color>";
+                        RealName = "<size=10000%><color=#000000>■</color></size>";
                 }
 
                 // Camouflage

--- a/Roles/Impostor/DollMaster.cs
+++ b/Roles/Impostor/DollMaster.cs
@@ -427,7 +427,7 @@ internal class DollMaster : RoleBase
     }
 
     // Set players cosmetics.
-    private static void RpcChangeSkin(PlayerControl player, PlayerControl target = null, NetworkedPlayerInfo.PlayerOutfit Outfit = null)
+        private static void RpcChangeSkin(PlayerControl player, PlayerControl target = null, NetworkedPlayerInfo.PlayerOutfit Outfit = null)
     {
         target ??= player;
         Outfit ??= Main.PlayerStates[target.PlayerId].NormalOutfit;
@@ -437,38 +437,45 @@ internal class DollMaster : RoleBase
             var sender = CustomRpcSender.Create(name: $"Reset PlayerOufit for 『{player.Data.PlayerName}』");
 
             player.SetName(Outfit.PlayerName);
+            player.Data.DefaultOutfit.PlayerName = Main.PlayerStates[player.PlayerId].NormalOutfit.PlayerName;
             sender.AutoStartRpc(player.NetId, (byte)RpcCalls.SetName)
                 .Write(player.Data.NetId)
                 .Write(Outfit.PlayerName)
             .EndRpc();
 
+
             Main.AllPlayerNames[player.PlayerId] = Outfit.PlayerName;
 
             player.SetColor(Outfit.ColorId);
+            player.Data.DefaultOutfit.ColorId = Main.PlayerStates[player.PlayerId].NormalOutfit.ColorId;
             sender.AutoStartRpc(player.NetId, (byte)RpcCalls.SetColor)
                 .Write(player.Data.NetId)
                 .Write((byte)Outfit.ColorId)
             .EndRpc();
 
             player.SetHat(Outfit.HatId, Outfit.ColorId);
+            player.Data.DefaultOutfit.HatId = Main.PlayerStates[player.PlayerId].NormalOutfit.HatId;
             sender.AutoStartRpc(player.NetId, (byte)RpcCalls.SetHatStr)
                 .Write(Outfit.HatId)
                 .Write(player.GetNextRpcSequenceId(RpcCalls.SetHatStr))
             .EndRpc();
 
             player.SetSkin(Outfit.SkinId, Outfit.ColorId);
+            player.Data.DefaultOutfit.SkinId = Main.PlayerStates[player.PlayerId].NormalOutfit.SkinId;
             sender.AutoStartRpc(player.NetId, (byte)RpcCalls.SetSkinStr)
                 .Write(Outfit.SkinId)
                 .Write(player.GetNextRpcSequenceId(RpcCalls.SetSkinStr))
             .EndRpc();
 
             player.SetVisor(Outfit.VisorId, Outfit.ColorId);
+            player.Data.DefaultOutfit.VisorId = Main.PlayerStates[player.PlayerId].NormalOutfit.VisorId;
             sender.AutoStartRpc(player.NetId, (byte)RpcCalls.SetVisorStr)
                 .Write(Outfit.VisorId)
                 .Write(player.GetNextRpcSequenceId(RpcCalls.SetVisorStr))
             .EndRpc();
 
             player.SetPet(Outfit.PetId);
+            player.Data.DefaultOutfit.PetId = Main.PlayerStates[player.PlayerId].NormalOutfit.PetId;
             sender.AutoStartRpc(player.NetId, (byte)RpcCalls.SetPetStr)
                 .Write(Outfit.PetId)
                 .Write(player.GetNextRpcSequenceId(RpcCalls.SetPetStr))

--- a/Roles/Impostor/DollMaster.cs
+++ b/Roles/Impostor/DollMaster.cs
@@ -22,8 +22,6 @@ internal class DollMaster : RoleBase
     private static bool WaitToUnPossess = false;
     public static PlayerControl controllingTarget = null; // Personal possessed player identifier for reference.
     public static PlayerControl DollMasterTarget = null; // Personal possessed player identifier for reference.
-    public static NetworkedPlayerInfo.PlayerOutfit controllingOutfit = null;
-    public static NetworkedPlayerInfo.PlayerOutfit DollMasterOutfit = null;
     private static float originalSpeed = float.MinValue;
     private static Vector2 controllingTargetPos = new(0, 0);
     private static Vector2 DollMasterPos = new(0, 0);
@@ -52,8 +50,6 @@ internal class DollMaster : RoleBase
         ReducedVisionPlayers.Clear();
         DollMasterTarget = null;
         controllingTarget = null;
-        controllingOutfit = null;
-        DollMasterOutfit = null;
     }
 
     public override void Add(byte playerId)
@@ -372,27 +368,21 @@ internal class DollMaster : RoleBase
     // Possess Player
     private static void Possess(PlayerControl pc, PlayerControl target, bool shouldAnimate = false)
     {
-        DollMasterOutfit = new NetworkedPlayerInfo.PlayerOutfit()
-            .Set(pc.GetRealName(), pc.CurrentOutfit.ColorId, pc.CurrentOutfit.HatId, pc.CurrentOutfit.SkinId, pc.CurrentOutfit.VisorId, pc.CurrentOutfit.PetId, pc.CurrentOutfit.NamePlateId);
-        controllingOutfit = new NetworkedPlayerInfo.PlayerOutfit()
-            .Set(target.GetRealName(), target.CurrentOutfit.ColorId, target.CurrentOutfit.HatId, target.CurrentOutfit.SkinId, target.CurrentOutfit.VisorId, target.CurrentOutfit.PetId, target.CurrentOutfit.NamePlateId);
-
         (target.MyPhysics.FlipX, pc.MyPhysics.FlipX) = (pc.MyPhysics.FlipX, target.MyPhysics.FlipX); // Copy the players directions that they are facing, Note this only works for modded clients!
         pc?.RpcShapeshift(target, false);
-        RpcChangeSkin(pc, controllingOutfit);
-        RpcChangeSkin(target, DollMasterOutfit);
+        RpcChangeSkin(pc, target);
+        RpcChangeSkin(target, pc);
+        RPC.SyncAllPlayerNames();
         pc?.Notify(Utils.ColorString(Utils.GetRoleColor(CustomRoles.DollMaster), GetString("DollMaster_PossessedTarget")));
     }
 
     // UnPossess Player
     private static void UnPossess(PlayerControl pc, PlayerControl target, bool shouldAnimate = false)
     {
-        WaitToUnPossess = false;
         (target.MyPhysics.FlipX, pc.MyPhysics.FlipX) = (pc.MyPhysics.FlipX, target.MyPhysics.FlipX); // Copy the players directions that they are facing, Note this only works for modded clients!
         pc?.RpcShapeshift(pc, false);
-        RpcChangeSkin(pc, DollMasterOutfit);
-        RpcChangeSkin(target, controllingOutfit);
-        pc?.RpcResetAbilityCooldown();
+        RpcChangeSkin(pc);
+        RpcChangeSkin(target);
 
         IsControllingPlayer = false;
         ResetPlayerSpeed = true;
@@ -400,7 +390,7 @@ internal class DollMaster : RoleBase
         {
             ReducedVisionPlayers.Clear();
             if (TargetDiesAfterPossession.GetBool() && !GameStates.IsMeeting) target.RpcMurderPlayer(target);
-        }, 0.35f);
+        }, 0.45f);
     }
 
     // Swap Dollmaster and possessed player info for functions.
@@ -437,44 +427,72 @@ internal class DollMaster : RoleBase
     }
 
     // Set players cosmetics.
-    private static void RpcChangeSkin(PlayerControl pc, NetworkedPlayerInfo.PlayerOutfit newOutfit)
+    private static void RpcChangeSkin(PlayerControl player, PlayerControl target = null, NetworkedPlayerInfo.PlayerOutfit Outfit = null)
     {
-        if (newOutfit is null) return;
+        target ??= player;
+        Outfit ??= Main.PlayerStates[target.PlayerId].NormalOutfit;
 
-        var sender = CustomRpcSender.Create(name: $"Doppelganger.RpcChangeSkin({pc.Data.PlayerName})");
-        pc.SetName(newOutfit.PlayerName);
-        sender.AutoStartRpc(pc.NetId, (byte)RpcCalls.SetName)
-        .Write(newOutfit.PlayerName)
-        .EndRpc();
+        void Setoutfit()
+        {
+            var sender = CustomRpcSender.Create(name: $"Reset PlayerOufit for 『{player.Data.PlayerName}』");
 
-        Main.AllPlayerNames[pc.PlayerId] = newOutfit.PlayerName;
-
-        pc.SetColor(newOutfit.ColorId);
-        sender.AutoStartRpc(pc.NetId, (byte)RpcCalls.SetColor)
-        .Write((byte)newOutfit.ColorId)
-        .EndRpc();
-
-        pc.SetHat(newOutfit.HatId, newOutfit.ColorId);
-        sender.AutoStartRpc(pc.NetId, (byte)RpcCalls.SetHatStr)
-            .Write(newOutfit.HatId)
-        .EndRpc();
-
-        pc.SetSkin(newOutfit.SkinId, newOutfit.ColorId);
-        sender.AutoStartRpc(pc.NetId, (byte)RpcCalls.SetSkinStr)
-            .Write(newOutfit.SkinId)
-        .EndRpc();
-
-        pc.SetVisor(newOutfit.VisorId, newOutfit.ColorId);
-        sender.AutoStartRpc(pc.NetId, (byte)RpcCalls.SetVisorStr)
-            .Write(newOutfit.VisorId)
-        .EndRpc();
-
-        pc.SetPet(newOutfit.PetId);
-        sender.AutoStartRpc(pc.NetId, (byte)RpcCalls.SetPetStr)
-            .Write(newOutfit.PetId)
+            player.SetName(Outfit.PlayerName);
+            sender.AutoStartRpc(player.NetId, (byte)RpcCalls.SetName)
+                .Write(player.Data.NetId)
+                .Write(Outfit.PlayerName)
             .EndRpc();
 
-        sender.SendMessage();
+            Main.AllPlayerNames[player.PlayerId] = Outfit.PlayerName;
+
+            player.SetColor(Outfit.ColorId);
+            sender.AutoStartRpc(player.NetId, (byte)RpcCalls.SetColor)
+                .Write(player.Data.NetId)
+                .Write((byte)Outfit.ColorId)
+            .EndRpc();
+
+            player.SetHat(Outfit.HatId, Outfit.ColorId);
+            sender.AutoStartRpc(player.NetId, (byte)RpcCalls.SetHatStr)
+                .Write(Outfit.HatId)
+                .Write(player.GetNextRpcSequenceId(RpcCalls.SetHatStr))
+            .EndRpc();
+
+            player.SetSkin(Outfit.SkinId, Outfit.ColorId);
+            sender.AutoStartRpc(player.NetId, (byte)RpcCalls.SetSkinStr)
+                .Write(Outfit.SkinId)
+                .Write(player.GetNextRpcSequenceId(RpcCalls.SetSkinStr))
+            .EndRpc();
+
+            player.SetVisor(Outfit.VisorId, Outfit.ColorId);
+            sender.AutoStartRpc(player.NetId, (byte)RpcCalls.SetVisorStr)
+                .Write(Outfit.VisorId)
+                .Write(player.GetNextRpcSequenceId(RpcCalls.SetVisorStr))
+            .EndRpc();
+
+            player.SetPet(Outfit.PetId);
+            sender.AutoStartRpc(player.NetId, (byte)RpcCalls.SetPetStr)
+                .Write(Outfit.PetId)
+                .Write(player.GetNextRpcSequenceId(RpcCalls.SetPetStr))
+                .EndRpc();
+
+            sender.SendMessage();
+
+            //cannot use currentoutfit type because of mushroom mixup . .
+            var OutfitTypeSet = player.CurrentOutfitType != PlayerOutfitType.Shapeshifted ? PlayerOutfitType.Default : PlayerOutfitType.Shapeshifted;
+
+            //Used instead of GameData.Instance.DirtyAllData();
+            foreach (var innerNetObject in GameData.Instance.AllPlayers)
+            {
+                innerNetObject.SetDirtyBit(uint.MaxValue);
+            }
+        }
+        if (player.CheckCamoflague())
+        {
+            Main.LateOutfits[target.PlayerId] = Setoutfit;
+        }
+        else
+        {
+            Setoutfit();
+        }
     }
 
     // Set name Suffix for Doll and Main Body under name.

--- a/Roles/Impostor/DollMaster.cs
+++ b/Roles/Impostor/DollMaster.cs
@@ -427,7 +427,7 @@ internal class DollMaster : RoleBase
     }
 
     // Set players cosmetics.
-        private static void RpcChangeSkin(PlayerControl player, PlayerControl target = null, NetworkedPlayerInfo.PlayerOutfit Outfit = null)
+    private static void RpcChangeSkin(PlayerControl player, PlayerControl target = null, NetworkedPlayerInfo.PlayerOutfit Outfit = null)
     {
         target ??= player;
         Outfit ??= Main.PlayerStates[target.PlayerId].NormalOutfit;


### PR DESCRIPTION
# Overview
More fixes for the beloved Dollmaster!
# Futures
```diff
+ Possibly fixed issue of players being swapped during meeting.
+ Fixed issue possessing player during comms camouflage sabotage.
+ Fixed desync issues with swapping players cosmetic.
+ Fixed Dollmaster color showing on map for possessed player.
+ Fixed possessed player being able to see self/dollmaster outfit inside a fungal mushroom cloud.
+ Fixed vanilla info diplay in Camouflage Comms.
```