### PR TITLE
Add new roles in alphabetical order in CustomRole Enum file

### DIFF
--- a/main.cs
+++ b/main.cs
@@ -534,29 +534,29 @@ public enum CustomRoles
 
     // Crewmate(Vanilla)
     Crewmate = 0,
-    Scientist,
     Engineer,
     GuardianAngel,
-    Tracker,
     Noisemaker,
+    Scientist,
+    Tracker,
 
     // Impostor(Vanilla)
     Impostor,
-    Shapeshifter,
     Phantom,
+    Shapeshifter,
 
     // Crewmate Vanilla Remakes
     CrewmateTOHE,
-    ScientistTOHE,
     EngineerTOHE,
     GuardianAngelTOHE,
-    TrackerTOHE,
     NoisemakerTOHE,
+    ScientistTOHE,
+    TrackerTOHE,
 
     // Impostor Vanilla Remakes
     ImpostorTOHE,
-    ShapeshifterTOHE,
     PhantomTOHE,
+    ShapeshifterTOHE,
 
     // Impostor Ghost
     Bloodmoon,
@@ -619,10 +619,9 @@ public enum CustomRoles
     Scavenger,
     ShapeMaster,
     Sniper,
-    Witch,
     SoulCatcher,
-    Swooper,
     Stealth,
+    Swooper,
     TimeThief,
     Trapster,
     Trickster,
@@ -634,6 +633,7 @@ public enum CustomRoles
     Visionary,
     Warlock,
     Wildling,
+    Witch,
     Zombie,
 
     //Crewmate Ghost
@@ -651,20 +651,21 @@ public enum CustomRoles
     Captain,
     Celebrity, 
     Chameleon,
+    ChiefOfPolice, //police commisioner ///// UNUSED
     Cleanser,
     CopyCat,
     Coroner, 
     Crusader,
-    Detective,
     Deceiver, 
     Deputy,
+    Detective,
     Dictator,
     Doctor,
     Enigma,
     FortuneTeller, 
+    Grenadier,
     Guardian,
     GuessMaster,
-    Grenadier,
     Inspector, 
     Investigator,
     Jailer,
@@ -689,12 +690,11 @@ public enum CustomRoles
     Oracle,
     Overseer, 
     Pacifist, 
-    ChiefOfPolice, //police commisioner ///// UNUSED
     President,
     Psychic,
     Randomizer,
-    Reverie,
     Retributionist,
+    Reverie,
     Sheriff,
     Snitch,
     SpeedBooster,
@@ -704,11 +704,10 @@ public enum CustomRoles
     Swapper,
     TaskManager,
     Telecommunication,
-    Tracefinder,
-    //Tracker,
-    Transporter,
     TimeManager,
     TimeMaster,
+    Tracefinder,
+    Transporter,
     Veteran,
     Vigilante,
     Witness,
@@ -746,14 +745,13 @@ public enum CustomRoles
     Opportunist,
     Pelican,
     Pestilence,
-    Specter,
     Pickpocket,
     Pirate,
     Pixie,
     PlagueBearer,
     PlagueDoctor,
-    PotionMaster,
     Poisoner,
+    PotionMaster,
     Provocateur,
     PunchingBag,
     Pursuer,
@@ -784,7 +782,7 @@ public enum CustomRoles
     Workaholic,
     Wraith,
 
-   //two-way camp
+    //two-way camp
     Mini,
 
     //FFA
@@ -799,7 +797,6 @@ public enum CustomRoles
     // Add-ons
     Admired,
     Antidote,
-    Glow,
     Autopsy,
     Avanger,
     Aware,
@@ -813,7 +810,6 @@ public enum CustomRoles
     Clumsy,
     Contagious,
     Cyber,
-    Unreportable, //disregarded
     Diseased,
     DoubleShot,
     Egoist,
@@ -822,6 +818,7 @@ public enum CustomRoles
     Fool,
     Fragile,
     Ghoul,
+    Glow,
     Gravestone,
     Guesser,
     Hurried,
@@ -835,7 +832,6 @@ public enum CustomRoles
     Lucky,
     Madmate,
     Mare,
-    Tricky,
     Mimic,
     Mundane,
     Necroview,
@@ -853,18 +849,20 @@ public enum CustomRoles
     Recruit,
     Seer,
     Silent,
-    Statue,
     Sleuth,
     Soulless,
-    TicketsStealer, //stealer
+    Statue,
     Stubborn,
     Susceptible,
     Swift,
     Tiebreaker,
+    TicketsStealer, //stealer
     Torch,
     Trapper,
+    Tricky,
     Tired,
     Unlucky,
+    Unreportable, //disregarded
     VoidBallot,
     Watcher,
     Workhorse,

--- a/main.cs
+++ b/main.cs
@@ -768,6 +768,7 @@ public enum CustomRoles
     Sidekick,
     Solsticer,
     SoulCollector,
+    Specter,
     Spiritcaller,
     Stalker,
     Sunnyboy,


### PR DESCRIPTION
Add new roles in alphabetical order in the `CustomRole` Enum file in `main.cs`.

* Add new roles such as `Admirer`, `Alchemist`, `Addict`, etc. (all of them), in alphabetical order.
* Ensure roles are listed alphabetically within their respective categories.
* Maintain the grouping of roles by categories such as Crewmate, Impostor, Neutral, etc.