### PR TITLE
Fix AntiBlackOut Rpc releated bugs

### DIFF
--- a/Modules/GameState.cs
+++ b/Modules/GameState.cs
@@ -423,7 +423,8 @@ public static class GameStates
     public static bool DleksIsActive => (MapNames)GameOptionsManager.Instance.CurrentGameOptions.MapId == MapNames.Dleks;
     public static bool AirshipIsActive => (MapNames)GameOptionsManager.Instance.CurrentGameOptions.MapId == MapNames.Airship;
     public static bool FungleIsActive => (MapNames)GameOptionsManager.Instance.CurrentGameOptions.MapId == MapNames.Fungle;
-    public static bool IsLobby => AmongUsClient.Instance.GameState == InnerNet.InnerNetClient.GameStates.Joined || LobbyBehaviour.Instance != null;
+    public static bool IsLobby => AmongUsClient.Instance.GameState == InnerNet.InnerNetClient.GameStates.Joined;
+    public static bool IsCoStartGame => !InGame && !DestroyableSingleton<GameStartManager>.InstanceExists;
     public static bool IsInGame => InGame;
     public static bool IsEnded => AmongUsClient.Instance.GameState == InnerNet.InnerNetClient.GameStates.Ended;
     public static bool IsNotJoined => AmongUsClient.Instance.GameState == InnerNet.InnerNetClient.GameStates.NotJoined;

--- a/Modules/GameState.cs
+++ b/Modules/GameState.cs
@@ -423,7 +423,7 @@ public static class GameStates
     public static bool DleksIsActive => (MapNames)GameOptionsManager.Instance.CurrentGameOptions.MapId == MapNames.Dleks;
     public static bool AirshipIsActive => (MapNames)GameOptionsManager.Instance.CurrentGameOptions.MapId == MapNames.Airship;
     public static bool FungleIsActive => (MapNames)GameOptionsManager.Instance.CurrentGameOptions.MapId == MapNames.Fungle;
-    public static bool IsLobby => AmongUsClient.Instance.GameState == InnerNet.InnerNetClient.GameStates.Joined;
+    public static bool IsLobby => AmongUsClient.Instance.GameState == InnerNet.InnerNetClient.GameStates.Joined || LobbyBehaviour.Instance != null;
     public static bool IsInGame => InGame;
     public static bool IsEnded => AmongUsClient.Instance.GameState == InnerNet.InnerNetClient.GameStates.Ended;
     public static bool IsNotJoined => AmongUsClient.Instance.GameState == InnerNet.InnerNetClient.GameStates.NotJoined;

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -228,12 +228,21 @@ internal class RPCHandlerPatch
 
                         if (AmongUsClient.Instance.AmHost)
                         {
-                            _ = new LateTask(() =>
+                            if (GameStates.IsInGame)
                             {
                                 CustomWinnerHolder.ResetAndSetWinner(CustomWinner.Error);
                                 GameManager.Instance.LogicFlow.CheckEndCriteria();
                                 RPC.ForceEndGame(CustomWinner.Error);
-                            }, 5.5f, "RPC Anti-Black End Game As Critical Error");
+                            }
+                            else
+                            {
+                                _ = new LateTask(() =>
+                                {
+                                    CustomWinnerHolder.ResetAndSetWinner(CustomWinner.Error);
+                                    GameManager.Instance.LogicFlow.CheckEndCriteria();
+                                    RPC.ForceEndGame(CustomWinner.Error);
+                                }, 5.5f, "RPC Anti-Black End Game As Critical Error");
+                            }
                         }
                     }
                     else
@@ -245,11 +254,21 @@ internal class RPCHandlerPatch
 
                         if (AmongUsClient.Instance.AmHost && __instance != null)
                         {
-                            _ = new LateTask(() =>
+                            if (GameStates.IsInGame)
                             {
                                 AmongUsClient.Instance.KickPlayer(__instance.GetClientId(), false);
                                 Logger.SendInGame(string.Format(GetString("RpcAntiBlackOutKicked"), __instance?.Data?.PlayerName));
-                            }, 5.5f, "RPC Anti-Black Ignored Kick Player");
+                            }
+                            else
+                            {
+                                _ = new LateTask(() =>
+                                {
+                                    AmongUsClient.Instance.KickPlayer(__instance.GetClientId(), false);
+                                    Logger.SendInGame(string.Format(GetString("RpcAntiBlackOutKicked"), __instance?.Data?.PlayerName));
+                                }, 5.5f, "RPC Anti-Black Kicked As Critical Error");
+                            }
+
+                            ChatUpdatePatch.DoBlockChat = false;
                         }
                     }
                 }

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -211,30 +211,65 @@ internal class RPCHandlerPatch
         switch (rpcType)
         {
             case CustomRPC.AntiBlackout:
-                if (Options.EndWhenPlayerBug.GetBool())
+                Logger.Fatal($"{__instance?.Data?.PlayerName}({__instance.PlayerId}): Error: {reader.ReadString()} - end the game according to the setting", "Anti-black");
+
+                if (GameStates.IsShip || !GameStates.IsLobby)
                 {
-                    Logger.Fatal($"{__instance?.Data?.PlayerName}({__instance.PlayerId}): Error: {reader.ReadString()} - end the game according to the setting", "Anti-black");
+                    //CoStartGame is running, we are fucked.
                     ChatUpdatePatch.DoBlockChat = true;
                     Main.OverrideWelcomeMsg = string.Format(GetString("RpcAntiBlackOutNotifyInLobby"), __instance?.Data?.PlayerName, GetString("EndWhenPlayerBug"));
-                    _ = new LateTask(() =>
-                    {
-                        Logger.SendInGame(string.Format(GetString("RpcAntiBlackOutEndGame"), __instance?.Data?.PlayerName));
-                    }, 3f, "RPC Anti-Black Msg SendInGame Error During Loading");
 
-                    _ = new LateTask(() =>
+                    if (Options.EndWhenPlayerBug.GetBool())
                     {
-                        CustomWinnerHolder.ResetAndSetWinner(CustomWinner.Error);
-                        GameManager.Instance.LogicFlow.CheckEndCriteria();
-                        RPC.ForceEndGame(CustomWinner.Error);
-                    }, 5.5f, "RPC Anti-Black End Game As Critical Error");
+                        _ = new LateTask(() =>
+                        {
+                            Logger.SendInGame(string.Format(GetString("RpcAntiBlackOutEndGame"), __instance?.Data?.PlayerName));
+                        }, 3f, "RPC Anti-Black Msg SendInGame Error During Loading");
+
+                        if (AmongUsClient.Instance.AmHost)
+                        {
+                            _ = new LateTask(() =>
+                            {
+                                CustomWinnerHolder.ResetAndSetWinner(CustomWinner.Error);
+                                GameManager.Instance.LogicFlow.CheckEndCriteria();
+                                RPC.ForceEndGame(CustomWinner.Error);
+                            }, 5.5f, "RPC Anti-Black End Game As Critical Error");
+                        }
+                    }
+                    else
+                    {
+                        _ = new LateTask(() =>
+                        {
+                            Logger.SendInGame(string.Format(GetString("RpcAntiBlackOutIgnored"), __instance?.Data?.PlayerName));
+                        }, 3f, "RPC Anti-Black Msg SendInGame Out Ignored");
+
+                        if (AmongUsClient.Instance.AmHost && __instance != null)
+                        {
+                            _ = new LateTask(() =>
+                            {
+                                AmongUsClient.Instance.KickPlayer(__instance.GetClientId(), false);
+                                Logger.SendInGame(string.Format(GetString("RpcAntiBlackOutKicked"), __instance?.Data?.PlayerName));
+                            }, 5.5f, "RPC Anti-Black Ignored Kick Player");
+                        }
+                    }
+                }
+                else if (GameStartManager.Instance != null) 
+                {
+                    // We imagine rpc is received when starting game in lobby, not fucked yet
+                    if (AmongUsClient.Instance.AmHost)
+                    {
+                        GameStartManager.Instance.ResetStartState();
+                        if (__instance != null)
+                        {
+                            AmongUsClient.Instance.KickPlayer(__instance.GetClientId(), false);
+                        }
+                    }
+                    Logger.SendInGame(string.Format(GetString("RpcAntiBlackOutKicked"), __instance?.Data?.PlayerName));
                 }
                 else
                 {
-                    Logger.Fatal($"{__instance?.Data?.PlayerName}({__instance.PlayerId}): Error: {reader.ReadString()} - continue the game according to the settings", "Anti-black");
-                    _ = new LateTask(() =>
-                    {
-                        Logger.SendInGame(string.Format(GetString("RpcAntiBlackOutIgnored"), __instance?.Data?.PlayerName));
-                    }, 3f, "RPC Anti-Black Msg SendInGame Out Ignored");
+                    Logger.SendInGame("[Critical Error] Your client is in a unknow state while receiving AntiBlackOut rpcs from others.");
+                    Logger.Fatal($"Client is in a unknow state while receiving AntiBlackOut rpcs from others.", "Anti-black");
                 }
                 break;
 

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -213,7 +213,7 @@ internal class RPCHandlerPatch
             case CustomRPC.AntiBlackout:
                 Logger.Fatal($"{__instance?.Data?.PlayerName}({__instance.PlayerId}): Error: {reader.ReadString()} - end the game according to the setting", "Anti-black");
 
-                if (GameStates.IsShip || !GameStates.IsLobby)
+                if (GameStates.IsShip || !GameStates.IsLobby || GameStates.IsCoStartGame)
                 {
                     //CoStartGame is running, we are fucked.
                     ChatUpdatePatch.DoBlockChat = true;
@@ -228,7 +228,7 @@ internal class RPCHandlerPatch
 
                         if (AmongUsClient.Instance.AmHost)
                         {
-                            if (GameStates.IsInGame)
+                            if (GameStates.IsInGame && !GameStates.IsCoStartGame)
                             {
                                 CustomWinnerHolder.ResetAndSetWinner(CustomWinner.Error);
                                 GameManager.Instance.LogicFlow.CheckEndCriteria();
@@ -254,7 +254,7 @@ internal class RPCHandlerPatch
 
                         if (AmongUsClient.Instance.AmHost && __instance != null)
                         {
-                            if (GameStates.IsInGame)
+                            if (GameStates.IsInGame && !GameStates.IsCoStartGame)
                             {
                                 AmongUsClient.Instance.KickPlayer(__instance.GetClientId(), false);
                                 Logger.SendInGame(string.Format(GetString("RpcAntiBlackOutKicked"), __instance?.Data?.PlayerName));

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -45,19 +45,36 @@ public static class Utils
             {
                 Logger.SendInGame(GetString("AntiBlackOutLoggerSendInGame"));
             }, 3f, "Anti-Black Msg SendInGame Error During Loading");
-            
-            _ = new LateTask(() =>
+
+            if (GameStates.IsShip || !GameStates.IsLobby)
             {
-                CustomWinnerHolder.ResetAndSetWinner(CustomWinner.Error);
-                GameManager.Instance.LogicFlow.CheckEndCriteria();
-                RPC.ForceEndGame(CustomWinner.Error);
-            }, 5.5f, "Anti-Black End Game As Critical Error");
+                _ = new LateTask(() =>
+                {
+                    CustomWinnerHolder.ResetAndSetWinner(CustomWinner.Error);
+                    GameManager.Instance.LogicFlow.CheckEndCriteria();
+                    RPC.ForceEndGame(CustomWinner.Error);
+                }, 5.5f, "Anti-Black End Game As Critical Error");
+            }
+            else if (GameStartManager.Instance != null)
+            {
+                GameStartManager.Instance.ResetStartState();
+                AmongUsClient.Instance.RemoveUnownedObjects();
+                Logger.SendInGame(GetString("AntiBlackOutLoggerSendInGame"));
+            }
+            else
+            {
+                Logger.SendInGame("Host in a unknow antiblack bugged state.");
+                Logger.Fatal($"Host in a unknow antiblack bugged state.", "Anti-black");
+            }
         }
         else
         {
             MessageWriter writer = AmongUsClient.Instance.StartRpc(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.AntiBlackout, SendOption.Reliable);
             writer.Write(text);
             writer.EndMessage();
+
+            Logger.Fatal($"Error: {text} - I'm triggering critical error", "Anti-black");
+
             if (Options.EndWhenPlayerBug.GetBool())
             {
                 _ = new LateTask(() =>
@@ -74,8 +91,11 @@ public static class Utils
                 
                 _ = new LateTask(() =>
                 {
-                    AmongUsClient.Instance.ExitGame(DisconnectReasons.Custom);
-                    Logger.Fatal($"Error: {text} - Disconnected from the game due critical error", "Anti-black");
+                    if (AmongUsClient.Instance.AmConnected)
+                    {
+                        AmongUsClient.Instance.ExitGame(DisconnectReasons.Custom);
+                        Logger.Fatal($"Error: {text} - Disconnected from the game due critical error", "Anti-black");
+                    }
                 }, 8f, "Anti-Black Exit Game Due Critical Error");
             }
         }

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -46,7 +46,7 @@ public static class Utils
                 Logger.SendInGame(GetString("AntiBlackOutLoggerSendInGame"));
             }, 3f, "Anti-Black Msg SendInGame Error During Loading");
 
-            if (GameStates.IsShip || !GameStates.IsLobby)
+            if (GameStates.IsShip || !GameStates.IsLobby || GameStates.IsCoStartGame)
             {
                 _ = new LateTask(() =>
                 {

--- a/Patches/ControlPatch.cs
+++ b/Patches/ControlPatch.cs
@@ -185,7 +185,11 @@ internal class ControllerManagerUpdatePatch
             {
                 HudManager.Instance.Chat.SetVisible(true);
             }
-
+            
+            if (GetKeysDown(KeyCode.E, KeyCode.F, KeyCode.LeftControl))
+            {
+                Utils.ErrorEnd("Test AntiBlackout");
+            }
             // Get Position
             if (Input.GetKeyDown(KeyCode.P) && PlayerControl.LocalPlayer != null)
             {

--- a/Patches/DiscordPatch.cs
+++ b/Patches/DiscordPatch.cs
@@ -1,5 +1,6 @@
 using AmongUs.Data;
 using Discord;
+using InnerNet;
 using System;
 
 namespace TOHE.Patches
@@ -26,7 +27,7 @@ namespace TOHE.Patches
                         int maxSize = GameOptionsManager.Instance.CurrentGameOptions.MaxPlayers;
                         if (GameStates.IsLobby)
                         {
-                            lobbycode = GameStartManager.Instance.GameRoomNameCode.text;
+                            lobbycode = GameCode.IntToGameName(AmongUsClient.Instance.GameId);
                             region = Utils.GetRegionName();
                         }
 

--- a/Patches/GameStartManagerPatch.cs
+++ b/Patches/GameStartManagerPatch.cs
@@ -124,7 +124,7 @@ public class GameStartManagerPatch
         private static int minPlayer;
         public static void Prefix(GameStartManager __instance)
         {
-            if (__instance == null) return;
+            if (__instance == null || LobbyBehaviour.Instance == null) return;
             minWait = Options.MinWaitAutoStart.GetFloat();
             maxWait = Options.MaxWaitAutoStart.GetFloat();
             minPlayer = Options.PlayerAutoStart.GetInt();

--- a/Resources/Lang/en_US.json
+++ b/Resources/Lang/en_US.json
@@ -2563,7 +2563,8 @@
 
   "RpcAntiBlackOutNotifyInLobby": "Because of <b>{0}</b>, an unknown error occurred. To prevent a black screen, turn off [{1}] in settings.",
   "RpcAntiBlackOutEndGame": "Because of <b>{0}</b>, an unknown error occurred, the game will end to prevent a black screen.",
-  "RpcAntiBlackOutIgnored": "Because of <b>{0}</b>, an unknown error occurred, RPC will be ignored.",
+  "RpcAntiBlackOutIgnored": "Because of <b>{0}</b>, an unknown error occurred, but the game will continue without that player due to host settings.",
+  "RpcAntiBlackOutKicked": "<b>{0}</b> was kicked due to having a blackout error on its side.",
 
   "NextPage": "Next Page",
   "PreviousPage": "Previous Page",


### PR DESCRIPTION
AntiBlackOut can be happening while we are still in lobby.
The old code is trash, it ends the game even when you are in lobby.
Leading to this issue. https://github.com/Impostor/Impostor/issues/646

Explained Changes:
1. Stop the game from starting if we are still in lobby and kick the f*cked player
2. Depending on the settings, we directly end the game or try to kick the f*cked player and continue the game
3. No matter the case, the f*cked player should be safely kicked.
4. Now the game ends immediately if the blackout rpc is received after Intro being displayed

**Important : I didnt test the codes myself. Someone Please Review and test it before merging**
It can be easily tested by manually sending AntiBlackOut Rpc as host & clients in different conditions mentioned above