### PR TITLE
Improvements for DisableUseVentForVanilla

### DIFF
--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -680,7 +680,7 @@ static class ExtendedPlayerControl
             _ => false
         };
     }
-    public static bool CanUseVent(this PlayerControl player) => player.CanUseImpostorVentButton() || player.Data.Role.Role == RoleTypes.Engineer;
+    public static bool CanUseVent(this PlayerControl player) => player.CanUseImpostorVentButton() || player.GetCustomRole().GetVNRole() == CustomRoles.Engineer;
     public static bool CanUseImpostorVentButton(this PlayerControl pc)
     {
         if (!pc.IsAlive()) return false;

--- a/Patches/IntroPatch.cs
+++ b/Patches/IntroPatch.cs
@@ -628,14 +628,19 @@ class IntroCutsceneDestroyPatch
                 PlayerControl.LocalPlayer.Data.Role.AffectedByLightAffectors = false;
             }
 
+            bool shouldPerformVentInteractions = false;
             foreach (var pc in PlayerControl.AllPlayerControls)
             {
-                VentSystemDeterioratePatch.LastClosestVent[pc.PlayerId] = pc.GetVentsFromClosest()[0].Id;
                 if (pc.BlockVentInteraction())
                 {
-                    Utils.SetAllVentInteractions();
-                    break;
+                    VentSystemDeterioratePatch.LastClosestVent[pc.PlayerId] = pc.GetVentsFromClosest()[0].Id;
+                    shouldPerformVentInteractions = true;
                 }
+            }
+
+            if (shouldPerformVentInteractions)
+            {
+                Utils.SetAllVentInteractions();
             }
         }
         Logger.Info("OnDestroy", "IntroCutscene");

--- a/Patches/ShipStatusPatch.cs
+++ b/Patches/ShipStatusPatch.cs
@@ -5,6 +5,7 @@ using TOHE.Roles.AddOns.Common;
 using TOHE.Roles.Neutral;
 using TOHE.Roles.Core;
 using static TOHE.Translator;
+using TOHE.Patches;
 
 namespace TOHE;
 
@@ -29,12 +30,13 @@ class ShipFixedUpdatePatch
         }
     }
 }
+
 [HarmonyPatch(typeof(ShipStatus), nameof(ShipStatus.UpdateSystem), typeof(SystemTypes), typeof(PlayerControl), typeof(MessageReader))]
 public static class MessageReaderUpdateSystemPatch
 {
     public static bool Prefix(ShipStatus __instance, [HarmonyArgument(0)] SystemTypes systemType, [HarmonyArgument(1)] PlayerControl player, [HarmonyArgument(2)] MessageReader reader)
     {
-        if (systemType is 
+        if (systemType is
             SystemTypes.Ventilation
             or SystemTypes.Security
             or SystemTypes.Decontamination
@@ -68,6 +70,7 @@ public static class MessageReaderUpdateSystemPatch
         UpdateSystemPatch.Postfix(__instance, systemType, player, MessageReader.Get(reader).ReadByte());
     }
 }
+
 [HarmonyPatch(typeof(ShipStatus), nameof(ShipStatus.UpdateSystem), typeof(SystemTypes), typeof(PlayerControl), typeof(byte))]
 class UpdateSystemPatch
 {
@@ -102,7 +105,7 @@ class UpdateSystemPatch
         if (player.Is(CustomRoles.Unlucky) && player.IsAlive()
             && (systemType is SystemTypes.Doors))
         {
-            if (Unlucky.SuicideRand(player, Unlucky.StateSuicide.OpenDoor)) 
+            if (Unlucky.SuicideRand(player, Unlucky.StateSuicide.OpenDoor))
                 return false;
         }
 
@@ -149,6 +152,7 @@ class UpdateSystemPatch
         }
     }
 }
+
 [HarmonyPatch(typeof(ShipStatus), nameof(ShipStatus.CloseDoorsOfType))]
 class ShipStatusCloseDoorsPatch
 {
@@ -167,6 +171,7 @@ class ShipStatusCloseDoorsPatch
         return allow;
     }
 }
+
 [HarmonyPatch(typeof(ShipStatus), nameof(ShipStatus.Start))]
 class StartPatch
 {
@@ -209,6 +214,7 @@ class StartPatch
         }
     }
 }
+
 [HarmonyPatch(typeof(ShipStatus), nameof(ShipStatus.StartMeeting))]
 class StartMeetingPatch
 {
@@ -227,6 +233,7 @@ class StartMeetingPatch
         }
     }
 }
+
 [HarmonyPatch(typeof(ShipStatus), nameof(ShipStatus.Begin))]
 class BeginPatch
 {
@@ -237,6 +244,7 @@ class BeginPatch
         //Should the initial setup of the host's position be done here?
     }
 }
+
 [HarmonyPatch(typeof(GameManager), nameof(GameManager.CheckTaskCompletion))]
 class CheckTaskCompletionPatch
 {
@@ -248,5 +256,90 @@ class CheckTaskCompletionPatch
             return false;
         }
         return true;
+    }
+}
+
+[HarmonyPatch(typeof(ShipStatus), nameof(ShipStatus.Serialize))]
+class ShipStatusSerializePatch
+{
+    // Patch the global way of Serializing ShipStatus
+    // If we are patching any other systemTypes, just add below like Ventilation.
+    public static bool Prefix(ShipStatus __instance, [HarmonyArgument(0)] MessageWriter writer, [HarmonyArgument(1)] bool initialState, ref bool __result)
+    {
+        __result = false;
+        if (!AmongUsClient.Instance.AmHost) return true;
+        if (initialState) return true;
+
+        // Original methods
+        short num = 0;
+        while ((int)num < SystemTypeHelpers.AllTypes.Length)
+        {
+            SystemTypes systemTypes = SystemTypeHelpers.AllTypes[(int)num];
+
+            if (systemTypes is SystemTypes.Ventilation)
+            {
+                // Skip Ventilation here
+                // Further new systems should skip original methods here and add new patches below.
+                num += 1;
+                continue;
+            }
+
+            ISystemType systemType;
+            if (__instance.Systems.TryGetValue(systemTypes, out systemType) && systemType.IsDirty) // initialState used here in vanilla code. Removed it.
+            {
+                __result = true;
+                writer.StartMessage((byte)systemTypes);
+                systemType.Serialize(writer, initialState);
+                writer.EndMessage();
+            }
+            num += 1;
+        }
+
+        // Ventilation part
+        {
+            Logger.Info("doing Ventilation Serialize", "ShipStatusSerializePatch");
+            // Serialize Ventilation with our own patches to clients specifically if needed
+            bool customVentilation = false;
+            foreach (var pc in PlayerControl.AllPlayerControls)
+            {
+                if (pc.BlockVentInteraction())
+                {
+                    customVentilation = true;
+                }
+            }
+
+            Logger.Info("customVentilation: " + customVentilation, "ShipStatusSerializePatch");
+            var ventilationSystem = __instance.Systems[SystemTypes.Ventilation].Cast<VentilationSystem>();
+            if (ventilationSystem != null && ventilationSystem.IsDirty)
+            {
+                if (customVentilation)
+                {
+                    Utils.SetAllVentInteractions();
+                }
+                else
+                {
+                    Logger.Info("vanilla update vents", "ShipStatusSerializePatch");
+                    var subwriter = MessageWriter.Get(SendOption.Reliable);
+                    subwriter.StartMessage(5);
+                    {
+                        subwriter.Write(AmongUsClient.Instance.GameId);
+                        subwriter.StartMessage(1);
+                        {
+                            subwriter.WritePacked(__instance.NetId);
+                            subwriter.StartMessage((byte)SystemTypes.Ventilation);
+                            ventilationSystem.Serialize(subwriter, false);
+                            subwriter.EndMessage();
+                        }
+                        subwriter.EndMessage();
+                    }
+                    subwriter.EndMessage();
+                    AmongUsClient.Instance.SendOrDisconnect(subwriter);
+                    subwriter.Recycle();
+                }
+                ventilationSystem.IsDirty = false;
+            }
+        }
+
+        return false;
     }
 }

--- a/Patches/ShipStatusPatch.cs
+++ b/Patches/ShipStatusPatch.cs
@@ -297,7 +297,7 @@ class ShipStatusSerializePatch
 
         // Ventilation part
         {
-            Logger.Info("doing Ventilation Serialize", "ShipStatusSerializePatch");
+            // Logger.Info("doing Ventilation Serialize", "ShipStatusSerializePatch");
             // Serialize Ventilation with our own patches to clients specifically if needed
             bool customVentilation = false;
 
@@ -315,14 +315,14 @@ class ShipStatusSerializePatch
             var ventilationSystem = __instance.Systems[SystemTypes.Ventilation].Cast<VentilationSystem>();
             if (ventilationSystem != null && ventilationSystem.IsDirty)
             {
-                Logger.Info("customVentilation: " + customVentilation, "ShipStatusSerializePatch");
+                // Logger.Info("customVentilation: " + customVentilation, "ShipStatusSerializePatch");
                 if (customVentilation)
                 {
                     Utils.SetAllVentInteractions();
                 }
                 else
                 {
-                    Logger.Info("vanilla update vents", "ShipStatusSerializePatch");
+                    // Logger.Info("vanilla update vents", "ShipStatusSerializePatch");
                     var subwriter = MessageWriter.Get(SendOption.Reliable);
                     subwriter.StartMessage(5);
                     {

--- a/Patches/ShipStatusPatch.cs
+++ b/Patches/ShipStatusPatch.cs
@@ -300,18 +300,22 @@ class ShipStatusSerializePatch
             Logger.Info("doing Ventilation Serialize", "ShipStatusSerializePatch");
             // Serialize Ventilation with our own patches to clients specifically if needed
             bool customVentilation = false;
-            foreach (var pc in PlayerControl.AllPlayerControls)
+
+            if (GameStates.IsInGame)
             {
-                if (pc.BlockVentInteraction())
+                foreach (var pc in PlayerControl.AllPlayerControls)
                 {
-                    customVentilation = true;
+                    if (pc.BlockVentInteraction())
+                    {
+                        customVentilation = true;
+                    }
                 }
             }
 
-            Logger.Info("customVentilation: " + customVentilation, "ShipStatusSerializePatch");
             var ventilationSystem = __instance.Systems[SystemTypes.Ventilation].Cast<VentilationSystem>();
             if (ventilationSystem != null && ventilationSystem.IsDirty)
             {
+                Logger.Info("customVentilation: " + customVentilation, "ShipStatusSerializePatch");
                 if (customVentilation)
                 {
                     Utils.SetAllVentInteractions();

--- a/Patches/VentSystemPatch.cs
+++ b/Patches/VentSystemPatch.cs
@@ -3,28 +3,8 @@ using System;
 
 namespace TOHE.Patches;
 
-[HarmonyPatch(typeof(ShipStatus), nameof(ShipStatus.Serialize))]
-class ShipStatusSerializePatch
-{
-    public static void Prefix(ShipStatus __instance, /*[HarmonyArgument(0)] MessageWriter writer,*/ [HarmonyArgument(1)] bool initialState)
-    {
-        if (!AmongUsClient.Instance.AmHost) return;
-        if (initialState) return;
-        bool cancel = false;
-        foreach (var pc in PlayerControl.AllPlayerControls)
-        {
-            if (pc.BlockVentInteraction())
-                cancel = true;
-        }
-        var ventilationSystem = __instance.Systems[SystemTypes.Ventilation].Cast<VentilationSystem>();
-        if (cancel && ventilationSystem != null && ventilationSystem.IsDirty)
-        {
-            Utils.SetAllVentInteractions();
-            ventilationSystem.IsDirty = false;
-        }
-
-    }
-}
+// Patches here is also activated from ShipStatus.Serialize and IntroCutScene 
+// through Utils.SetAllVentInteractions
 
 [HarmonyPatch(typeof(VentilationSystem), nameof(VentilationSystem.Deteriorate))]
 static class VentSystemDeterioratePatch
@@ -50,16 +30,11 @@ static class VentSystemDeterioratePatch
     {
         if (!pc.AmOwner && !pc.IsModClient() && !pc.Data.IsDead && !pc.CanUseVent())
         {
-            //foreach (var vent in ShipStatus.Instance.AllVents)
-            //{
-            //    if ()
-            //        return true;
-            //}
-
             return true;
         }
         return false;
     }
+
     public static void SerializeV2(VentilationSystem __instance, PlayerControl player = null)
     {
         foreach (var pc in PlayerControl.AllPlayerControls)

--- a/Patches/VentSystemPatch.cs
+++ b/Patches/VentSystemPatch.cs
@@ -104,6 +104,7 @@ static class VentSystemDeterioratePatch
         AmongUsClient.Instance.SendOrDisconnect(writer);
         writer.Recycle();
     }
+
     private static void RpcSerializeVent(this PlayerControl pc, VentilationSystem __instance)
     {
         MessageWriter writer = MessageWriter.Get(SendOption.None);


### PR DESCRIPTION
the old methods delays other dirty system types from updating when ventilation is dirty
Though it has little influence on real game play, i still decide to patch shipstatus like what we have done to Networked PlayerInfo

1. Move Serialize patch of shipstatus to shipstatus.cs and improve it so it wont delay other system types from updating
2. CanUseVent used to use player.data.role.role == engineer, obviously it sucks. Changed to GetVNRole
3. In IntroCutscene the old code stop adding LastVentId when it meets a "true". fixed that so last vent id is added to all needed players
4. Before IntroCutscene got destoryed (game really starts), the old code is serializing Vents (before role get assigned). This may make the first 2 vents in Skeld unusable. Fixed by delaying updating the custom vents until intro is being played