### PR TITLE
Jester not being able to get Rebirth

### DIFF
--- a/Modules/CustomRolesHelper.cs
+++ b/Modules/CustomRolesHelper.cs
@@ -1079,6 +1079,10 @@ public static class CustomRolesHelper
                 if ((pc.GetCustomRole().IsCrewmate() && !Statue.CanBeOnCrew.GetBool()) || (pc.GetCustomRole().IsNeutral() && !Statue.CanBeOnNeutral.GetBool()) || (pc.GetCustomRole().IsImpostor() && !Statue.CanBeOnImp.GetBool()))
                     return false;
                 break;
+            case CustomRoles.Rebirth:
+                if (pc.Is(CustomRoles.Jester)
+                    return false;
+                break;        
         }
 
         return true;

--- a/Modules/CustomRolesHelper.cs
+++ b/Modules/CustomRolesHelper.cs
@@ -1080,7 +1080,7 @@ public static class CustomRolesHelper
                     return false;
                 break;
             case CustomRoles.Rebirth:
-                if (pc.Is(CustomRoles.Jester)
+                if (pc.Is(CustomRoles.Jester))
                     return false;
                 break;        
         }


### PR DESCRIPTION
If Jester gets the Rebirth add-on, it defeats Jester's purpose and will cause a bug where the Jester will swap skins with whoever's skin they take, and the player who they swapped their skins with will become a ghost, and the Jester will be alive. Plus the names would swap and the victory screen will be wrong.