### PR TITLE
Jester and Zombie can't get Rebirth

### DIFF
--- a/Modules/CustomRolesHelper.cs
+++ b/Modules/CustomRolesHelper.cs
@@ -738,7 +738,9 @@ public static class CustomRolesHelper
                 break;
 
             case CustomRoles.Rebirth:
-                if (pc.Is(CustomRoles.Doppelganger)) return false;
+                if (pc.Is(CustomRoles.Doppelganger) 
+                    || pc.Is(CustomRoles.Jester)
+                    || pc.Is(CustomRoles.Zombie)) return false;
                 break;
 
             case CustomRoles.Youtuber:


### PR DESCRIPTION
If Jester gets the Rebirth add-on, it defeats Jester's purpose and will cause a bug where the Jester will swap skins with whoever's skin they take, and the player who they swapped their skins with will become a ghost, and the Jester will be alive. Plus the names would swap and the victory screen will be wrong. Zombie because they cant get voted out anyways, unless by dictator.